### PR TITLE
add base Makefile with core installation targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,35 @@
 
 ## Installation
 
-The `install` folder contains resource files to provision a strimzi operator, kafka cluster and our monitoring stack on an openshift cluster. 
+The `install` folder contains resource files and a Makefile to provision a strimzi operator, kafka cluster and our monitoring stack on an openshift cluster.
 
-To manually provision a cluster follow the steps in `install/installation-guide.md`.
+### Prerequisites
+
+- running openshift 4 cluster and kubeadmin credentials
+- oc and kubectl binaries
+
+### Installation via Makefile
+
+Available `make` targets:
+
+```sh
+# install the global monitoring base stack
+install/global/monitoring
+
+# install the strimzi operator
+install/strimzi/operator
+
+# install monitoring resources for strimzi operator
+install/strimzi/monitoring
+
+# install kafka cr
+install/kafka/cr
+
+# install monitoring resources for kafka cr
+install/kafka/monitoring
+```
+
+
+### Manual installation
+
+If a manual installation is preferred follow the manual steps in `install/installation-guide.md`.

--- a/install/Makefile
+++ b/install/Makefile
@@ -1,0 +1,20 @@
+STRIMZI_OPERATOR_TAG ?= 0.19.0
+STRIMZI_OPERATOR_NAMESPACE ?= openshift-kafka-operator
+KAFKA_CLUSTER_NAMESPACE ?= openshift-kafka-cluster
+GRAFANA_NAMESPACE ?= kafka-grafana
+RESOURCE_FILES_DIR ?= ./resources
+
+.PHONY: install/global/monitoring
+install/global/monitoring:
+
+.PHONY: install/strimzi/operator
+install/strimzi/operator:
+
+.PHONY: install/strimzi/monitoring
+install/strimzi/monitoring:
+
+.PHONY: install/kafka/cr
+install/kafka/cr:
+
+.PHONY: install/kafka/monitoring
+install/kafka/monitoring:


### PR DESCRIPTION
## What

Create base Makefile with core installation targets :
https://issues.redhat.com/browse/MGDSTRM-164

## Why

We need a means to install our necessary workstream components within the 30-day time frame. Base Makefile to be updated with target implementations in subsequent PRs.

## How

Add Makefile targets for the automation of the manual steps in the [current installation-guide](https://github.com/RHCloudServices/kafka-monitoring-stuff/blob/master/install/installation-guide.md)