### PR TITLE
Add install/strimzi/operator Make target

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+<!--  Issue these changes relate to -->
+## What
+
+<!-- Why these changes are required -->
+## Why
+
+<!-- How this PR implements these changes  -->
+## How
+

--- a/install/Makefile
+++ b/install/Makefile
@@ -2,6 +2,7 @@ STRIMZI_OPERATOR_NAMESPACE ?= openshift-operators
 KAFKA_CLUSTER_NAMESPACE ?= openshift-kafka-cluster
 PER_CLUSTER_MONITORING_NAMESPACE ?= kafka-monitoring-cluster
 GLOBAL_MONITORING_NAMESPACE ?= kafka-monitoring-global
+KAFKA_PVC_SIZE ?= 10Gi
 RESOURCE_FILES_DIR ?= ./resources
 BUILD_DIR := build
 
@@ -28,6 +29,19 @@ install/strimzi/monitoring:
 
 .PHONY: install/kafka/cr
 install/kafka/cr:
+	@ echo "creating deploy files..."
+	@ mkdir ./$(BUILD_DIR)
+	@ cp $(RESOURCE_FILES_DIR)/cluster/kafka.yaml ./$(BUILD_DIR)
+	@ sed -i 's/<KAFKA_CLUSTER_NAMESPACE>/$(KAFKA_CLUSTER_NAMESPACE)/' ./$(BUILD_DIR)/kafka.yaml
+	@ sed -i 's/<PVC_SIZE>/$(KAFKA_PVC_SIZE)/' ./$(BUILD_DIR)/kafka.yaml
+
+	@ echo "deploying kafka cluster to $(KAFKA_CLUSTER_NAMESPACE) namespace..."
+	@ kubectl create ns $(KAFKA_CLUSTER_NAMESPACE)
+	@ oc apply -f ./$(BUILD_DIR)/kafka.yaml
+	@ echo "kafka cluster deployed to $(KAFKA_CLUSTER_NAMESPACE) namespace..."
+
+	@ echo "cleaning up deployment files..."
+	@ rm -rf ./$(BUILD_DIR)
 
 .PHONY: install/kafka/monitoring
 install/kafka/monitoring:

--- a/install/Makefile
+++ b/install/Makefile
@@ -1,15 +1,27 @@
-STRIMZI_OPERATOR_TAG ?= 0.19.0
-STRIMZI_OPERATOR_NAMESPACE ?= openshift-kafka-operator
+STRIMZI_OPERATOR_NAMESPACE ?= openshift-operators
 KAFKA_CLUSTER_NAMESPACE ?= openshift-kafka-cluster
 PER_CLUSTER_MONITORING_NAMESPACE ?= kafka-monitoring-cluster
 GLOBAL_MONITORING_NAMESPACE ?= kafka-monitoring-global
 RESOURCE_FILES_DIR ?= ./resources
+BUILD_DIR := build
 
 .PHONY: install/global/monitoring
 install/global/monitoring:
 
 .PHONY: install/strimzi/operator
 install/strimzi/operator:
+	@ echo "creating deploy files..."
+	@ wget https://operatorhub.io/install/strimzi-kafka-operator.yaml -P ./$(BUILD_DIR)
+	@ sed -i 's/namespace: .*/namespace: $(STRIMZI_OPERATOR_NAMESPACE)/' ./$(BUILD_DIR)/strimzi-kafka-operator.yaml
+	@ sed -i 's/source: .*/source: community-operators/' ./$(BUILD_DIR)/strimzi-kafka-operator.yaml
+	@ sed -i 's/sourceNamespace: .*/sourceNamespace: openshift-marketplace/' ./$(BUILD_DIR)/strimzi-kafka-operator.yaml
+
+	@ echo "deploying strimzi operator to $(STRIMZI_OPERATOR_NAMESPACE) namespace..."
+	#@ kubectl create ns $(STRIMZI_OPERATOR_NAMESPACE)
+	@ oc apply -f ./$(BUILD_DIR)/ 
+
+	@ echo "cleaning up deployment files..."
+	@ rm -rf ./$(BUILD_DIR)
 
 .PHONY: install/strimzi/monitoring
 install/strimzi/monitoring:

--- a/install/resources/cluster/kafka.yaml
+++ b/install/resources/cluster/kafka.yaml
@@ -2,6 +2,7 @@ apiVersion: kafka.strimzi.io/v1beta1
 kind: Kafka
 metadata:
   name: my-cluster
+  namespace: <KAFKA_CLUSTER_NAMESPACE>
 spec:
   kafka:
     replicas: 1
@@ -16,7 +17,7 @@ spec:
       volumes:
       - id: 0
         type: persistent-claim
-        size: 10Gi
+        size: <PVC_SIZE>
         deleteClaim: false
     config:
       offsets.topic.replication.factor: 1
@@ -123,7 +124,7 @@ spec:
     replicas: 1
     storage:
       type: persistent-claim
-      size: 10Gi
+      size: <PVC_SIZE>
       deleteClaim: false
     metrics:
       # Inspired by Zookeeper rules


### PR DESCRIPTION
## What
Add a means to install strimzi operator to an OSD cluster via OLM. https://issues.redhat.com/browse/MGDSTRM-167

## Why
We need a way to install the strimzi operator on a cluster until the service api implementation is available

## How
Create an OLM subscription to the strimzi-operator on the cluster

Note: this has been tested locally on a crc cluster, but not on an OSD cluster.