### PR TITLE
Removed Kafka Entity Operator

### DIFF
--- a/install/resources/kafka/kafka.yaml
+++ b/install/resources/kafka/kafka.yaml
@@ -165,6 +165,3 @@ spec:
       - pattern: "org.apache.ZooKeeperService<name0=StandaloneServer_port(\\d+), name1=InMemoryDataTree><>(\\w+)"
         type: GAUGE
         name: "zookeeper_$2"
-  entityOperator:
-    topicOperator: {}
-    userOperator: {}


### PR DESCRIPTION
This PR just removes the Entity Operator from the `Kafka` recourse because we are not going to use it.