### PR TITLE
adds ability to configure chaos test targets

### DIFF
--- a/install/resources/testing-chaos/Makefile
+++ b/install/resources/testing-chaos/Makefile
@@ -1,3 +1,10 @@
+POD_DELETE_APP_LABEL ?= app.kubernetes.io/name=kafka
+POD_DELETE_DEPLOYMENT_TYPE ?= statefulset
+POD_DELETE_CLEANUP ?= retain
+POD_DELETE_DURATION ?= 60
+POD_DELETE_INTERVAL ?= 10
+POD_DELETE_FORCE ?= false
+
 .PHONY: create/operator
 create/operator:
 	@echo "create operator: litmus"
@@ -6,14 +13,25 @@ create/operator:
 .PHONY: create/chaosexperiments
 create/chaosexperiments:
 	@echo "create chaosexperiments: $(KAFKA_CLUSTER_NAMESPACE)"
-	@kubectl apply -f ./chaosexperiments/chaosexperiments-generic.yaml -n kafka-cluster
-	@kubectl apply -f ./chaosexperiments/chaosexperiments-kafka.yaml -n kafka-cluster
+	@kubectl apply -f ./chaosexperiments/chaosexperiments-generic.yaml -n $(KAFKA_CLUSTER_NAMESPACE)
+	@kubectl apply -f ./chaosexperiments/chaosexperiments-kafka.yaml -n $(KAFKA_CLUSTER_NAMESPACE)
 
 .PHONY: create/chaosengine/pod-delete
 create/chaosengine/pod-delete: 
 	@echo "create pod-delete: $(KAFKA_CLUSTER_NAMESPACE)"
-	@kubectl apply -f ./chaosengines/pod-delete/serviceaccount.yaml
-	@kubectl apply -f ./chaosengines/pod-delete/chaosengine.yaml
+	@cat ./chaosengines/pod-delete/serviceaccount.yaml | \
+		sed -e 's/<namespace>/$(KAFKA_CLUSTER_NAMESPACE)/g' | \
+		cat | oc apply -f -
+
+	@cat ./chaosengines/pod-delete/chaosengine.yaml | \
+    sed -e 's|<namespace>|$(KAFKA_CLUSTER_NAMESPACE)|g' | \
+    sed -e 's|<pod-label>|$(POD_DELETE_APP_LABEL)|g' | \
+    sed -e 's|<deployment-type>|$(POD_DELETE_DEPLOYMENT_TYPE)|g' | \
+    sed -e 's|<cleanup>|$(POD_DELETE_CLEANUP)|g' | \
+    sed -e 's|<chaos-duration>|$(POD_DELETE_DURATION)|g' | \
+    sed -e 's|<chaos-interval>|$(POD_DELETE_INTERVAL)|g' | \
+    sed -e 's|<force-delete>|$(POD_DELETE_FORCE)|g' | \
+    cat > oc apply -f -
 
 all: create/operator create/chaosexperiments create/chaosengine/pod-delete
 	@echo "Done deploying chaos experiments"

--- a/install/resources/testing-chaos/chaosengines/pod-delete/chaosengine.yaml
+++ b/install/resources/testing-chaos/chaosengines/pod-delete/chaosengine.yaml
@@ -2,12 +2,12 @@ apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
   name: pod-delete
-  namespace: kafka-cluster
+  namespace: <namespace>
 spec:
   appinfo:
-    appns: 'kafka-cluster'
-    applabel: 'app.kubernetes.io/name=kafka'
-    appkind: 'statefulset'
+    appns: '<namespace>'
+    applabel: '<pod-label>'
+    appkind: '<deployment-type>'
   # It can be true/false
   annotationCheck: 'false'
   # It can be active/stop
@@ -17,7 +17,7 @@ spec:
   chaosServiceAccount: pod-delete-sa
   monitoring: false
   # It can be delete/retain
-  jobCleanUpPolicy: 'retain'
+  jobCleanUpPolicy: '<cleanup>'
   experiments:
     - name: pod-delete
       spec:
@@ -25,12 +25,12 @@ spec:
           env:
             # set chaos duration (in sec) as desired
             - name: TOTAL_CHAOS_DURATION
-              value: '60'
+              value: '<chaos-duration>'
 
             # set chaos interval (in sec) as desired
             - name: CHAOS_INTERVAL
-              value: '10'
+              value: '<chaos-interval>'
               
             # pod failures without '--force' & default terminationGracePeriodSeconds
             - name: FORCE
-              value: 'false'
+              value: '<force-delete>'

--- a/install/resources/testing-chaos/chaosengines/pod-delete/serviceaccount.yaml
+++ b/install/resources/testing-chaos/chaosengines/pod-delete/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: pod-delete-sa
-  namespace: kafka-cluster
+  namespace: <namespace>
   labels:
     name: pod-delete-sa
 ---
@@ -11,7 +11,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: pod-delete-sa
-  namespace: kafka-cluster
+  namespace: <namespace>
   labels:
     name: pod-delete-sa
 rules:
@@ -23,7 +23,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: pod-delete-sa
-  namespace: kafka-cluster
+  namespace: <namespace>
   labels:
     name: pod-delete-sa
 roleRef:
@@ -33,4 +33,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: pod-delete-sa
-  namespace: kafka-cluster
+  namespace: <namespace>


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What
Adds ability to configure pod-delete chaos experiment

<!-- Why these changes are required -->
## Why

<!-- How this PR implements these changes  -->
## How

