### PR TITLE
refactors litmus operator to run in centralised mode

### DIFF
--- a/install/resources/testing-chaos/Makefile
+++ b/install/resources/testing-chaos/Makefile
@@ -1,3 +1,4 @@
+KAFKA_CLUSTER_NAMESPACE ?= kafka-cluster
 POD_DELETE_APP_LABEL ?= app.kubernetes.io/name=kafka
 POD_DELETE_DEPLOYMENT_TYPE ?= statefulset
 POD_DELETE_CLEANUP ?= retain
@@ -12,17 +13,13 @@ create/operator:
 
 .PHONY: create/chaosexperiments
 create/chaosexperiments:
-	@echo "create chaosexperiments: $(KAFKA_CLUSTER_NAMESPACE)"
-	@kubectl apply -f ./chaosexperiments/chaosexperiments-generic.yaml -n $(KAFKA_CLUSTER_NAMESPACE)
-	@kubectl apply -f ./chaosexperiments/chaosexperiments-kafka.yaml -n $(KAFKA_CLUSTER_NAMESPACE)
+	@echo "create chaosexperiment resources"
+	@kubectl apply -f ./chaosexperiments/chaosexperiments-generic.yaml
+	@kubectl apply -f ./chaosexperiments/chaosexperiments-kafka.yaml
 
 .PHONY: create/chaosengine/pod-delete
 create/chaosengine/pod-delete: 
-	@echo "create pod-delete: $(KAFKA_CLUSTER_NAMESPACE)"
-	@cat ./chaosengines/pod-delete/serviceaccount.yaml | \
-		sed -e 's/<namespace>/$(KAFKA_CLUSTER_NAMESPACE)/g' | \
-		cat | oc apply -f -
-
+	@echo "create pod-delete chaosengine"
 	@cat ./chaosengines/pod-delete/chaosengine.yaml | \
     sed -e 's|<namespace>|$(KAFKA_CLUSTER_NAMESPACE)|g' | \
     sed -e 's|<pod-label>|$(POD_DELETE_APP_LABEL)|g' | \
@@ -31,7 +28,7 @@ create/chaosengine/pod-delete:
     sed -e 's|<chaos-duration>|$(POD_DELETE_DURATION)|g' | \
     sed -e 's|<chaos-interval>|$(POD_DELETE_INTERVAL)|g' | \
     sed -e 's|<force-delete>|$(POD_DELETE_FORCE)|g' | \
-    cat > oc apply -f -
+    cat | oc apply -f -
 
 all: create/operator create/chaosexperiments create/chaosengine/pod-delete
 	@echo "Done deploying chaos experiments"

--- a/install/resources/testing-chaos/chaosengines/pod-delete/chaosengine.yaml
+++ b/install/resources/testing-chaos/chaosengines/pod-delete/chaosengine.yaml
@@ -2,7 +2,7 @@ apiVersion: litmuschaos.io/v1alpha1
 kind: ChaosEngine
 metadata:
   name: pod-delete
-  namespace: <namespace>
+  namespace: litmus
 spec:
   appinfo:
     appns: '<namespace>'
@@ -14,7 +14,7 @@ spec:
   engineState: 'active'
   #ex. values: ns1:name=percona,ns2:run=nginx
   auxiliaryAppInfo: ''
-  chaosServiceAccount: pod-delete-sa
+  chaosServiceAccount: litmus-admin
   monitoring: false
   # It can be delete/retain
   jobCleanUpPolicy: '<cleanup>'

--- a/install/resources/testing-chaos/chaosexperiments/chaosexperiments-generic.yaml
+++ b/install/resources/testing-chaos/chaosexperiments/chaosexperiments-generic.yaml
@@ -7,6 +7,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-network-duplication
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced
@@ -92,6 +93,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: node-drain
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -162,6 +164,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: node-io-stress
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -248,6 +251,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: disk-fill
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -328,6 +332,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: node-taint
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -403,6 +408,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-autoscaler
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -472,6 +478,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-cpu-hog
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced
@@ -546,6 +553,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-memory-hog
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced
@@ -617,6 +625,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-network-corruption
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced
@@ -704,6 +713,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-delete
+  namespace: litmus
   version: 0.1.19
 spec:
   definition:
@@ -781,6 +791,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-network-loss
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced
@@ -868,6 +879,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: disk-loss
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -953,6 +965,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-io-stress
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced
@@ -1028,6 +1041,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: k8-service-kill
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced
@@ -1106,6 +1120,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: pod-network-latency
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced
@@ -1194,6 +1209,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: node-cpu-hog
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -1271,6 +1287,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: docker-service-kill
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -1335,6 +1352,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: kubelet-service-kill
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -1405,6 +1423,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: node-memory-hog
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -1482,6 +1501,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: k8-pod-delete
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced
@@ -1559,6 +1579,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: container-kill
+  namespace: litmus
 spec:
   definition:
     scope: Namespaced

--- a/install/resources/testing-chaos/chaosexperiments/chaosexperiments-kafka.yaml
+++ b/install/resources/testing-chaos/chaosexperiments/chaosexperiments-kafka.yaml
@@ -7,6 +7,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: kafka-broker-pod-failure
+  namespace: litmus
 spec:
   definition:
     scope: Cluster
@@ -136,6 +137,7 @@ description:
 kind: ChaosExperiment
 metadata:
   name: kafka-broker-disk-failure
+  namespace: litmus
 spec:
   definition:
     scope: Cluster

--- a/install/resources/testing-chaos/operator/litmus-operator-v1.8.2.yaml
+++ b/install/resources/testing-chaos/operator/litmus-operator-v1.8.2.yaml
@@ -6,38 +6,46 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: litmus
+  name: litmus-admin
   namespace: litmus
   labels:
-    name: litmus
+    name: litmus-admin
 ---
+# Source: openebs/templates/clusterrole.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: litmus
+  name: litmus-admin
   labels:
-    name: litmus
+    name: litmus-admin
 rules:
-- apiGroups: ["","apps","batch","litmuschaos.io","apps.openshift.io"]
-  resources: ["pods","jobs","deployments","replicationcontrollers","daemonsets","replicasets","statefulsets","deploymentconfigs","events","configmaps","services","secrets","chaosengines","chaosexperiments","chaosresults"]
-  verbs: ["get","create","update","patch","delete","list","watch","deletecollection"]
-- apiGroups: ["admissionregistration.k8s.io"]
-  resources: ["validatingwebhookconfigurations"]
-  verbs: ["get","create","list","delete","update"]
+- apiGroups: ["","apps","batch","extensions","litmuschaos.io"]
+  resources: ["pods","pods/exec","pods/eviction","jobs","daemonsets","events","chaosresults","chaosengines"]
+  verbs: ["create","delete","get","list","patch","update", "deletecollection"]
+- apiGroups: ["","apps","litmuschaos.io"]
+  resources: ["configmaps","secrets","services","chaosexperiments","pods/log","replicasets","deployments","statefulsets","services"]
+  verbs: ["create","get","list","patch","update"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get","list","patch","update"]
+# additional perms required to deploy chaosexperiment into litmus operator ns
+- apiGroups: ["","litmuschaos.io","batch","apps"]
+  resources: [deployments","pods/log",chaosexperiments"]
+  verbs: ["create","list","get","patch","update","delete","deletecollection"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: litmus
+  name: litmus-admin
   labels:
-    name: litmus
+    name: litmus-admin
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: litmus
+  name: litmus-admin
 subjects:
 - kind: ServiceAccount
-  name: litmus
+  name: litmus-admin
   namespace: litmus
 ---
 apiVersion: apps/v1
@@ -55,7 +63,7 @@ spec:
       labels:
         name: chaos-operator
     spec:
-      serviceAccountName: litmus
+      serviceAccountName: litmus-admin
       containers:
         - name: chaos-operator
           image: litmuschaos/chaos-operator:1.8.2


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What

Refactor litmus operator so chaos resources are deployed to litmus operator ns rather than the ns of the app under test

<!-- Why these changes are required -->
## Why

Separation of concerns

<!-- How this PR implements these changes  -->
## How

Update service account used by litmus operator so it has all the permissions it needs to run chaos experiments in app ns's. 
Update all chaos resources to deploy into litmus operator ns.
