### PR TITLE
Add missing metric to federate list for firing alerts

### DIFF
--- a/install/resources/monitoring-cluster/prometheus/federation.yaml
+++ b/install/resources/monitoring-cluster/prometheus/federation.yaml
@@ -23,6 +23,7 @@
       - '{__name__=~"instance:.*"}'
       - '{__name__=~"container_memory_.*"}'
       - '{__name__=~"container_cpu_.*"}'
+      - '{__name__="container_last_seen"}'
       - '{__name__=~":node_memory_.*"}'
       - '{__name__=~"csv_.*"}'
   scheme: https


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What
Downstream https://issues.redhat.com/browse/MGDSTRM-269
Numerous alerts firing due to missing metric

<!-- Why these changes are required -->
## Why
not included in federate list from cluster stack

<!-- How this PR implements these changes  -->
## How
add the metric to the federate config
