### PR TITLE
Using container CPU usage including kernel time

### DIFF
--- a/install/resources/monitoring-cluster/dashboards/strimzi-kafka.yaml
+++ b/install/resources/monitoring-cluster/dashboards/strimzi-kafka.yaml
@@ -817,7 +817,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_user_seconds_total{namespace=\"$kubernetes_namespace\",pod=~\"$strimzi_cluster_name-$kafka_broker\",container=\"kafka\"}[5m])) by (pod)",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$kubernetes_namespace\",pod=~\"$strimzi_cluster_name-$kafka_broker\",container=\"kafka\"}[5m])) by (pod)",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,

--- a/install/resources/monitoring-cluster/dashboards/strimzi-zookeeper.yaml
+++ b/install/resources/monitoring-cluster/dashboards/strimzi-zookeeper.yaml
@@ -616,7 +616,7 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(container_cpu_user_seconds_total{namespace=\"$kubernetes_namespace\",container=\"zookeeper\",pod=~\"$strimzi_cluster_name-$zk_node\"}[5m])) by (pod)",
+              "expr": "sum(rate(container_cpu_usage_seconds_total{namespace=\"$kubernetes_namespace\",container=\"zookeeper\",pod=~\"$strimzi_cluster_name-$zk_node\"}[5m])) by (pod)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{pod}}",


### PR DESCRIPTION
## What

This PR updates the ZooKeeper and Kafka dashboards using the `container_cpu_usage_seconds_total` metric instead of the `container_cpu_user_seconds_total`.

## Why
It's because this metric includes the kernel CPU time other than the user one which of course has an impact on request limits for Kafka and ZooKeeper pods so it's better having them included on the graph.
It was raised even upstream in Strimzi https://github.com/strimzi/strimzi-kafka-operator/issues/3909 and fixed there https://github.com/strimzi/strimzi-kafka-operator/pull/3910

## How
Just changing the metric name.

