### PR TITLE
Add error budget burn alert for failed produce & consume/fetch requests

### DIFF
--- a/install/resources/monitoring-cluster/prometheus/prometheus-rules.yaml
+++ b/install/resources/monitoring-cluster/prometheus/prometheus-rules.yaml
@@ -7,6 +7,287 @@ metadata:
   namespace: <namespace>
 spec:
   groups:
+  - name: kafka-api-slo
+    rules:
+    - alert: ErrorBudgetBurn_ProduceRequests
+      annotations:
+        message: 'High error budget burn for Failed Produce Requests (current value: {{ $value }})'
+      expr: |
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate5m{}) > (14.40 * (1-0.90000))
+        and
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1h{}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        name: FailedProduceRequestsPerSec
+        severity: critical
+    - alert: ErrorBudgetBurn_ProduceRequests
+      annotations:
+        message: 'High error budget burn for Failed Produce Requests (current value: {{ $value }})'
+      expr: |
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate30m{}) > (6.00 * (1-0.90000))
+        and
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h{}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        name: FailedProduceRequestsPerSec
+        severity: critical
+    - alert: ErrorBudgetBurn_ProduceRequests
+      annotations:
+        message: 'High error budget burn for Failed Produce Requests (current value: {{ $value }})'
+      expr: |
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate2h{}) > (3.00 * (1-0.90000))
+        and
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1d{}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        name: FailedProduceRequestsPerSec
+        severity: warning
+    - alert: ErrorBudgetBurn_ProduceRequests
+      annotations:
+        message: 'High error budget burn for Failed Produce Requests (current value: {{ $value }})'
+      expr: |
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h{}) > (1.00 * (1-0.90000))
+        and
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate3d{}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        name: FailedProduceRequestsPerSec
+        severity: warning
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total{}[1d]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total{}[1d]))
+      labels:
+        name: FailedProduceRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1d
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total{}[1h]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total{}[1h]))
+      labels:
+        name: FailedProduceRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1h
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total{}[2h]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total{}[2h]))
+      labels:
+        name: FailedProduceRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate2h
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total{}[30m]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total{}[30m]))
+      labels:
+        name: FailedProduceRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate30m
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total{}[3d]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total{}[3d]))
+      labels:
+        name: FailedProduceRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate3d
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total{}[5m]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total{}[5m]))
+      labels:
+        name: FailedProduceRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate5m
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total{}[6h]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total{}[6h]))
+      labels:
+        name: FailedProduceRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h
+    - alert: ErrorBudgetBurn_FetchRequests
+      annotations:
+        message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
+      expr: |
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate5m{}) > (14.40 * (1-0.90000))
+        and
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1h{}) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        name: FailedFetchRequestsPerSec
+        severity: critical
+    - alert: ErrorBudgetBurn_FetchRequests
+      annotations:
+        message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
+      expr: |
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate30m{}) > (6.00 * (1-0.90000))
+        and
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h{}) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        name: FailedFetchRequestsPerSec
+        severity: critical
+    - alert: ErrorBudgetBurn_FetchRequests
+      annotations:
+        message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
+      expr: |
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate2h{}) > (3.00 * (1-0.90000))
+        and
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1d{}) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        name: FailedFetchRequestsPerSec
+        severity: warning
+    - alert: ErrorBudgetBurn_FetchRequests
+      annotations:
+        message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
+      expr: |
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h{}) > (1.00 * (1-0.90000))
+        and
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate3d{}) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        name: FailedFetchRequestsPerSec
+        severity: warning
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total{}[1d]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total{}[1d]))
+      labels:
+        name: FailedFetchRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1d
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total{}[1h]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total{}[1h]))
+      labels:
+        name: FailedFetchRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1h
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total{}[2h]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total{}[2h]))
+      labels:
+        name: FailedFetchRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate2h
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total{}[30m]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total{}[30m]))
+      labels:
+        name: FailedFetchRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate30m
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total{}[3d]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total{}[3d]))
+      labels:
+        name: FailedFetchRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate3d
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total{}[5m]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total{}[5m]))
+      labels:
+        name: FailedFetchRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate5m
+    - expr: |
+        sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total{}[6h]))
+        /
+        sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total{}[6h]))
+      labels:
+        name: FailedFetchRequestsPerSec
+      record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h
+    - alert: ErrorBudgetBurn_Connections
+      annotations:
+        message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
+      expr: |
+        sum(haproxy_server_connection_errors_total:burnrate5m{) > (14.40 * (1-0.90000))
+        and
+        sum(haproxy_server_connection_errors_total:burnrate1h{) > (14.40 * (1-0.90000))
+      for: 2m
+      labels:
+        name: FailedConnectionsPerSec
+        severity: critical
+    - alert: ErrorBudgetBurn_Connections
+      annotations:
+        message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
+      expr: |
+        sum(haproxy_server_connection_errors_total:burnrate30m{) > (6.00 * (1-0.90000))
+        and
+        sum(haproxy_server_connection_errors_total:burnrate6h{) > (6.00 * (1-0.90000))
+      for: 15m
+      labels:
+        name: FailedConnectionsPerSec
+        severity: critical
+    - alert: ErrorBudgetBurn_Connections
+      annotations:
+        message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
+      expr: |
+        sum(haproxy_server_connection_errors_total:burnrate2h{) > (3.00 * (1-0.90000))
+        and
+        sum(haproxy_server_connection_errors_total:burnrate1d{) > (3.00 * (1-0.90000))
+      for: 1h
+      labels:
+        name: FailedConnectionsPerSec
+        severity: warning
+    - alert: ErrorBudgetBurn_Connections
+      annotations:
+        message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
+      expr: |
+        sum(haproxy_server_connection_errors_total:burnrate6h{) > (1.00 * (1-0.90000))
+        and
+        sum(haproxy_server_connection_errors_total:burnrate3d{) > (1.00 * (1-0.90000))
+      for: 3h
+      labels:
+        name: FailedConnectionsPerSec
+        severity: warning
+    - expr: |
+        sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[1d]))
+        /
+        sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[1d]))
+      labels:
+        name: FailedConnectionsPerSec
+      record: haproxy_server_connection_errors_total:burnrate1d
+    - expr: |
+        sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[1h]))
+        /
+        sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[1h]))
+      labels:
+        name: FailedConnectionsPerSec
+      record: haproxy_server_connection_errors_total:burnrate1h
+    - expr: |
+        sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[2h]))
+        /
+        sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[2h]))
+      labels:
+        name: FailedConnectionsPerSec
+      record: haproxy_server_connection_errors_total:burnrate2h
+    - expr: |
+        sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[30m]))
+        /
+        sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[30m]))
+      labels:
+        name: FailedConnectionsPerSec
+      record: haproxy_server_connection_errors_total:burnrate30m
+    - expr: |
+        sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[3d]))
+        /
+        sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[3d]))
+      labels:
+        name: FailedConnectionsPerSec
+      record: haproxy_server_connection_errors_total:burnrate3d
+    - expr: |
+        sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[5m]))
+        /
+        sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[5m]))
+      labels:
+        name: FailedConnectionsPerSec
+      record: haproxy_server_connection_errors_total:burnrate5m
+    - expr: |
+        sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[6h]))
+        /
+        sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[6h]))
+      labels:
+        name: FailedConnectionsPerSec
+      record: haproxy_server_connection_errors_total:burnrate6h
   - name: kafka
     rules:
     - alert: KafkaPersistentVolumeFillingUp


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What
Create Error Budget burn rate alerts for:

* produce requests
* fetch(consume) requests
* tcp connections via exposed kafka routes (brokers & bootstrap round robin)

<!-- Why these changes are required -->
## Why
(downstream issue https://issues.redhat.com/browse/MGDSTRM-479)

<!-- How this PR implements these changes  -->
## How
Based on the rule generator at https://promtools.dev/alerts/errors
