### PR TITLE
Add kafka cluster traffic generation to fault tests 

### DIFF
--- a/install/resources/testing-chaos/Makefile
+++ b/install/resources/testing-chaos/Makefile
@@ -1,4 +1,5 @@
 KAFKA_CLUSTER_NAMESPACE ?= kafka-cluster
+KAFKA_CLUSTER_NAME ?= my-cluster
 BROKER_POD_LABEL ?= app.kubernetes.io/name=kafka
 BROKER_DEPLOYMENT_TYPE ?= statefulset
 ZOOKEEPER_POD_LABEL ?= app.kubernetes.io/name=zookeeper
@@ -33,6 +34,14 @@ create/chaosexperiments:
 	@echo "create chaosexperiment resources"
 	@kubectl apply -f ./chaosexperiments/chaosexperiments-generic.yaml
 	@kubectl apply -f ./chaosexperiments/chaosexperiments-kafka.yaml
+
+.PHONY: create/strimzi-traffic-generator
+create/strimzi-traffic-generator:
+	@echo "create strimzi-traffic-generator: $(KAFKA_CLUSTER_NAMESPACE)"
+	@cat ./strimzi-traffic-generator/deployment.yaml | \
+    sed -e 's|<namespace>|$(KAFKA_CLUSTER_NAMESPACE)|g' | \
+    sed -e 's|<kafka-cluster-name>|$(KAFKA_CLUSTER_NAME)|g' | \
+    cat | oc apply -f -
 
 .PHONY: create/chaosschedule/pod-delete-brokers
 create/chaosschedule/pod-delete-brokers: 
@@ -97,5 +106,5 @@ uninstall/operator/litmus:
 	@oc delete ns litmus
 	@echo "Done removing litmus resources"
 
-all: create/operator create/chaosexperiments create/operator/chaosscheduler create/chaosschedule/pod-delete-brokers create/chaosschedule/pod-delete-zookeepers
+all: create/operator create/chaosexperiments create/operator/chaosscheduler create/strimzi-traffic-generator create/chaosschedule/pod-delete-brokers create/chaosschedule/pod-delete-zookeepers
 	@echo "Done deploying chaos experiments"

--- a/install/resources/testing-chaos/strimzi-traffic-generator/deployment.yaml
+++ b/install/resources/testing-chaos/strimzi-traffic-generator/deployment.yaml
@@ -1,0 +1,54 @@
+kind: "DeploymentConfig"
+apiVersion: "v1"
+metadata:
+  name: strimzi-traffic-generator
+  namespace: <namespace>
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: strimzi-traffic-generator
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: traffic-generator
+          image: quay.io/damurphy/go-stoker:bbb564e
+          volumeMounts:
+            - name: cluster-ca
+              mountPath: /etc/cluster-ca
+              readOnly: true
+            - name: client-ca
+              mountPath: /etc/client-ca
+              readOnly: true
+            - name: client-ca-cert
+              mountPath: /etc/client-ca-cert
+              readOnly: true
+          env:
+            - name: KAFKA_BOOTSTRAP_SERVERS
+              value: '<kafka-cluster-name>-kafka-bootstrap:9092'
+            - name: TOPIC
+              value: 'traffic-gen-topic'
+            - name: SEND_RATE
+              value: '1'
+            - name: PRODUCER_CLIENT_ID
+              value: 'traffic-gen-client'
+            - name: TLS_ENABLED
+              value: 'false'
+      volumes:
+        - name: cluster-ca
+          secret:
+            secretName: <kafka-cluster-name>-cluster-ca-cert
+            defaultMode: 288
+        - name: client-ca-cert
+          secret:
+            secretName: <kafka-cluster-name>-clients-ca-cert
+            defaultMode: 288
+        - name: client-ca
+          secret:
+            secretName: <kafka-cluster-name>-clients-ca
+            defaultMode: 288
+          imagePullPolicy: IfNotPresent
+      dnsPolicy: ClusterFirst
+  triggers:
+    - type: ConfigChange


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What
https://issues.redhat.com/browse/MGDSTRM-521. Add kafka cluster traffic generation to fault tests. 

<!-- Why these changes are required -->
## Why
Fault tests are currently run against static kafka cluster targets without any messaging traffic.

<!-- How this PR implements these changes  -->
## How
Add deployment and make targets for go-stoker tool

