### PR TITLE
Set default logging level for zookeeper components to WARN

### DIFF
--- a/install/resources/kafka/kafka.yaml
+++ b/install/resources/kafka/kafka.yaml
@@ -130,6 +130,10 @@ spec:
       type: persistent-claim
       size: <PVC_SIZE>
       deleteClaim: false
+    logging:
+      loggers:
+        zookeeper.root.logger: WARN
+      type: inline
     metrics:
       lowercaseOutputName: true
       rules:


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What
Changes default logging level for zookeeper pods from INFO to WARN
<!-- Why these changes are required -->
## Why
Zookeeper pods seems generate excessive amount of logs on default level such as 
_2020-10-09 05:57:19,420 INFO Processing ruok command from /127.0.0.1:57132 (org.apache.zookeeper.server.NettyServerCnxn) [nioEventLoopGroup-4-2]_
Which are most likely caused by the readiness probe. Out of all logs generated from kafka cluster zookeeper pods responsible for 96% of the log entries . Recommendation is to adjust log level to WARN for zookeeper to reduce log volumes sent to Observatorium 

<!-- How this PR implements these changes  -->
## How
kafka CR now includes explicit logging definition
