### PR TITLE
Promtail conf

### DIFF
--- a/install/Makefile
+++ b/install/Makefile
@@ -118,7 +118,7 @@ test/chaos:
 setup/observatorium:
 	make -C resources/observatorium setup
 
-all: install/strimzi/operator install/kafka/cr
+all: install/strimzi/operator install/kafka/cr install/monitoring/global install/monitoring/cluster
 	@echo "done installing kafka monitoring demo"
 
 clean: uninstall/kafka/cr uninstall/strimzi/operator uninstall/monitoring/global uninstall/monitoring/cluster

--- a/install/Makefile
+++ b/install/Makefile
@@ -118,7 +118,7 @@ test/chaos:
 setup/observatorium:
 	make -C resources/observatorium setup
 
-all: install/strimzi/operator install/kafka/cr install/monitoring/global install/monitoring/cluster
+all: install/strimzi/operator install/kafka/cr
 	@echo "done installing kafka monitoring demo"
 
 clean: uninstall/kafka/cr uninstall/strimzi/operator uninstall/monitoring/global uninstall/monitoring/cluster

--- a/install/resources/monitoring-cluster/prometheus/datasource.yaml
+++ b/install/resources/monitoring-cluster/prometheus/datasource.yaml
@@ -27,7 +27,7 @@ spec:
     - name: "Observatorium-Metrics"
       type: prometheus
       access: proxy
-      url: <observatorium>
+      url: <gateway>/api/metrics/v1/<tenant>
       isDefault: false
       version: 1
       editable: true
@@ -48,7 +48,7 @@ spec:
     - name: "Observatorium-Logs"
       type: loki
       access: proxy
-      url: <observatorium>
+      url: <gateway>/api/logs/v1/<tenant>
       isDefault: false
       version: 1
       editable: true

--- a/install/resources/monitoring-cluster/promtail/config.yaml
+++ b/install/resources/monitoring-cluster/promtail/config.yaml
@@ -19,18 +19,12 @@ data:
             cluster_id:
         relabel_configs:
         - source_labels:
-          - __meta_kubernetes_pod_label_name
-          target_label: __service__
-        - source_labels:
           - __meta_kubernetes_pod_node_name
           target_label: __host__
         - action: replace
-          replacement: $1
-          separator: /
           source_labels:
-          - __meta_kubernetes_namespace
-          - __service__
-          target_label: job
+          - __meta_kubernetes_pod_node_name
+          target_label: nodename
         - action: replace
           source_labels:
           - __meta_kubernetes_namespace
@@ -44,7 +38,8 @@ data:
           - __meta_kubernetes_pod_container_name
           target_label: container_name
         - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
+          regex: __meta_kubernetes_pod_label_strimzi_io_(.+)
+          replacement: strimzi_io_$1
         - replacement: /var/log/pods/*$1/*.log
           separator: /
           source_labels:

--- a/install/resources/monitoring-cluster/promtail/promtail.yaml
+++ b/install/resources/monitoring-cluster/promtail/promtail.yaml
@@ -64,18 +64,12 @@ data:
             cluster_id:
         relabel_configs:
         - source_labels:
-          - __meta_kubernetes_pod_label_name
-          target_label: __service__
-        - source_labels:
           - __meta_kubernetes_pod_node_name
           target_label: __host__
         - action: replace
-          replacement: $1
-          separator: /
           source_labels:
-          - __meta_kubernetes_namespace
-          - __service__
-          target_label: job
+          - __meta_kubernetes_pod_node_name
+          target_label: nodename
         - action: replace
           source_labels:
           - __meta_kubernetes_namespace
@@ -89,7 +83,8 @@ data:
           - __meta_kubernetes_pod_container_name
           target_label: container_name
         - action: labelmap
-          regex: __meta_kubernetes_pod_label_(.+)
+          regex: __meta_kubernetes_pod_label_strimzi_io_(.+)
+          replacement: strimzi_io_$1
         - replacement: /var/log/pods/*$1/*.log
           separator: /
           source_labels:

--- a/install/resources/observatorium/Makefile
+++ b/install/resources/observatorium/Makefile
@@ -31,6 +31,11 @@ create/cr:
 	@echo "create observatorium in: $(OBSERVATORIUM_NAMESPACE)"
 	@sed 's/<namespace>/$(OBSERVATORIUM_NAMESPACE)/g' ./observatorium.yaml | cat | oc apply -f -
 
+.PHONY: create/route
+create/route:
+	@echo "create route"
+	@sed 's/<namespace>/$(OBSERVATORIUM_NAMESPACE)/g' ./route.yaml | cat | oc apply -f -
+
 setup:
 	@echo "updating promtail config to point to $(GATEWAY_URL)"
 	@cat ../monitoring-cluster/promtail/config.yaml | sed -e 's/<namespace>/$(PER_CLUSTER_GRAFANA_NAMESPACE)/g' | \
@@ -48,6 +53,12 @@ setup:
         sed -e 's#<gateway>#$(GATEWAY_URL)/api/metrics/v1/test/api/v1/receive#g' | \
         sed -e 's/<token>/$(shell curl --request POST --url $(DEX_TOKEN_URL)/dex/token --header 'content-type: application/x-www-form-urlencoded' --data grant_type=password --data username=admin@example.com --data password=password --data client_id=test --data client_secret=ZXhhbXBsZS1hcHAtc2VjcmV0 --data scope="openid email" | sed 's/^{.*"id_token":[^"]*"\([^"]*\)".*}/\1/')/g' | \
 		cat | oc apply -f -
+	@echo "updating data sources"
+	@cat ../monitoring-cluster/prometheus/datasource.yaml | sed -e 's/<url>/'"$(PER_CLUSTER_PROMETHEUS_NAMESPACE)"'/g' | \
+        sed -e 's#<gateway>#$(GATEWAY_URL)#g' | \
+        sed -e 's/<tenant>/test/g' | \
+        sed -e 's/<token>/$(shell curl --request POST --url $(DEX_TOKEN_URL)/dex/token --header 'content-type: application/x-www-form-urlencoded' --data grant_type=password --data username=admin@example.com --data password=password --data client_id=test --data client_secret=ZXhhbXBsZS1hcHAtc2VjcmV0 --data scope="openid email" | sed 's/^{.*"id_token":[^"]*"\([^"]*\)".*}/\1/')/g' | \
+		cat | oc apply -n $(PER_CLUSTER_GRAFANA_NAMESPACE) -f -
 	@echo "restarting promtail"
 	@oc get pods -n $(PER_CLUSTER_GRAFANA_NAMESPACE) --selector=app=kafka-promtail -oyaml | oc delete -f -
 
@@ -57,5 +68,5 @@ clean:
 	@oc delete namespace $(OBSERVATORIUM_NAMESPACE)
 	@echo "Done uninstalling observatorium"
 
-all: create/dex create/minio create/crds create/operator create/cr
+all: create/dex create/minio create/crds create/operator create/cr create/route
 	@echo "Done installing observatorium"

--- a/install/resources/observatorium/observatorium.yaml
+++ b/install/resources/observatorium/observatorium.yaml
@@ -30,8 +30,8 @@ spec:
     image: 'docker.io/grafana/loki:1.6.1'
     replicas:
       distributor: 1
-      ingester: 1
-      querier: 1
+      ingester: 3
+      querier: 3
       query_frontend: 1
       table_manager: 1
     version: 1.6.1

--- a/install/resources/observatorium/route.yaml
+++ b/install/resources/observatorium/route.yaml
@@ -1,0 +1,17 @@
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: observatorium
+  namespace: <namespace>
+spec:
+  host: observatorium-observatorium.apps-crc.testing
+  to:
+    kind: Service
+    name: observatorium-xyz-observatorium-api
+    weight: 100
+  port:
+    targetPort: public
+  tls:
+    termination: passthrough
+    insecureEdgeTerminationPolicy: Redirect
+  wildcardPolicy: None


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What
Removed most of the dynamically created kubernetes labels , removed job labels as they were constructed from redundant namespace labels and non-existent kubernetes for kafka pods name labels. 
 
<!-- Why these changes are required -->
## Why
Only logs from kafka specific components are meant to be sent to Observatorium and as result we can control set of labels needed to match log information with metrics while keeping loki metadata small and reduce cardinality of the data. Certain flexibility can be still achieved through io_strimzi_* specific kubernetes labels that are still being created using `labelmap` relabeling stanza

<!-- How this PR implements these changes  -->
## How

Config Map has been changed in  `config.yaml` and `promtail.yaml` files