### PR TITLE
"MGDSTRM-570:listeners for kaflka CR"

### DIFF
--- a/install/Makefile
+++ b/install/Makefile
@@ -2,6 +2,7 @@ export KAFKA_PVC_SIZE ?= 5Gi
 
 export STRIMZI_OPERATOR_NAMESPACE ?= kafka-operator
 export KAFKA_CLUSTER_NAMESPACE ?= kafka-cluster
+export KAFKA_CLUSTER_NAME?= my-cluster
 
 export PER_CLUSTER_PROMETHEUS_NAMESPACE ?= managed-services-monitoring-prometheus
 export PER_CLUSTER_GRAFANA_NAMESPACE ?= managed-services-monitoring-grafana
@@ -24,6 +25,10 @@ export OBSERVATORIUM_NAMESPACE ?= observatorium
 export OBSERVATORIUM_APPS_URL ?= apps.example.io
 
 export CLUSTER_ID ?= $(shell oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}')
+
+# kafka listener vars
+export KAFKA_CLUSTER_DOMAIN_NAME ?= $(oc get --namespace openshift-ingress-operator ingresscontrollers/default --output jsonpath='{.status.domain}{"\n"}')
+export KAFKA_UUID ?= $(uuidgen)
 
 RESOURCE_FILES_DIR ?= ./resources
 BUILD_DIR := build

--- a/install/resources/kafka/Makefile
+++ b/install/resources/kafka/Makefile
@@ -7,7 +7,10 @@ create/namespace:
 create/kafka:
 	@echo "create kafka cluster: $(KAFKA_CLUSTER_NAMESPACE)"
 	@cat ./kafka.yaml | sed -e 's/<NAMESPACE>/$(KAFKA_CLUSTER_NAMESPACE)/g' | \
+	    sed -e 's/<NAME>/$(KAFKA_CLUSTER_NAME)/g' | \
+		sed -e 's/<UUID>/$(KAFKA_UUID)/g' | \
 		sed -e 's/<PVC_SIZE>/$(KAFKA_PVC_SIZE)/g' | \
+		sed -e 's/<CLUSTER_DOMAIN_NAME>/$(KAFKA_CLUSTER_DOMAIN_NAME)/g' | \
 		cat | oc apply -f -
 
 all: create/namespace create/kafka

--- a/install/resources/kafka/kafka.yaml
+++ b/install/resources/kafka/kafka.yaml
@@ -1,17 +1,26 @@
 apiVersion: kafka.strimzi.io/v1beta1
 kind: Kafka
 metadata:
-  name: my-cluster
+  name: <NAME>
   namespace: <NAMESPACE>
 spec:
   kafka:
     replicas: 3
     listeners:
+      external:
+        overrides:
+          bootstrap:
+            host: <NAME>-<UUID>.<CLUSTER_DOMAIN_NAME>
+          brokers:
+            - broker: 0
+              host: broker-0-<NAME>-<UUID>.<CLUSTER_DOMAIN_NAME>
+            - broker: 1
+              host: broker-1-<NAME>-<UUID>.<CLUSTER_DOMAIN_NAME>
+            - broker: 2
+              host: broker-2-<NAME>-<UUID>.<CLUSTER_DOMAIN_NAME>
+        type: route
       plain: {}
       tls: {}
-      external:
-        type: nodeport
-        tls: false
     storage:
       type: jbod
       volumes:


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## Added external listeners to kafka bootstrap and kafka brokers

<!-- Why these changes are required -->
## To ensure development using the scripts in https://github.com/RHCloudServices/kafka-monitoring-stuff is as close as possible to what the service api creates, update the listener config in https://github.com/RHCloudServices/kafka-monitoring-stuff/blob/master/install/resources/kafka/kafka.yaml#L9-L14 to match.
This will require some dynamic logic to get the cluster dns suffix and construct the hosts.



