### PR TITLE
Alerts fault test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
+.vscode
 install/build
 .DS_Store

--- a/install/resources/testing-chaos/Makefile
+++ b/install/resources/testing-chaos/Makefile
@@ -1,3 +1,6 @@
+LITMUS_NS ?= litmus
+CLUSTER_PROMETHEUS_NS ?= managed-services-monitoring-prometheus
+PROMETHEUS_SCRAPE_INTERVAL ?= 30
 KAFKA_CLUSTER_NAMESPACE ?= kafka-cluster
 KAFKA_CLUSTER_NAME ?= my-cluster
 BROKER_POD_LABEL ?= app.kubernetes.io/name=kafka
@@ -90,6 +93,10 @@ create/chaosengine/pod-delete:
     sed -e 's|<force-delete>|$(POD_DELETE_FORCE)|g' | \
     cat | oc apply -f -
 
+.PHONY: test/chaosschedule/critical-alerts
+test/chaosschedule/critical-alerts:
+	@python3 ./scripts/fault-test.py $(LITMUS_NS) $(CLUSTER_PROMETHEUS_NS) $(PROMETHEUS_SCRAPE_INTERVAL)
+
 .PHONY: uninstall/operator/chaosscheduler
 uninstall/operator/chaosscheduler:
 	@echo "removing chaosscheduler resources"
@@ -106,5 +113,5 @@ uninstall/operator/litmus:
 	@oc delete ns litmus
 	@echo "Done removing litmus resources"
 
-all: create/operator/litmus create/chaosexperiments create/operator/chaosscheduler create/strimzi-traffic-generator create/chaosschedule/pod-delete-brokers create/chaosschedule/pod-delete-zookeepers
+all: create/operator/litmus create/chaosexperiments create/operator/chaosscheduler create/strimzi-traffic-generator create/chaosschedule/pod-delete-brokers create/chaosschedule/pod-delete-zookeepers test/chaosschedule/critical-alerts
 	@echo "Done deploying chaos experiments"

--- a/install/resources/testing-chaos/chaosschedules/pod-delete-brokers/chaosschedule.yaml
+++ b/install/resources/testing-chaos/chaosschedules/pod-delete-brokers/chaosschedule.yaml
@@ -5,10 +5,7 @@ metadata:
   namespace: litmus
 spec:
   schedule:
-    repeat:
-      properties:
-         #format should be like "10m" or "2h" accordingly for minutes or hours
-        minChaosInterval: "<chaos-schedule-interval>"  
+    now: true 
   engineTemplateSpec:
     engineState: active
     appinfo:

--- a/install/resources/testing-chaos/chaosschedules/pod-delete-zookeepers/chaosschedule.yaml
+++ b/install/resources/testing-chaos/chaosschedules/pod-delete-zookeepers/chaosschedule.yaml
@@ -5,10 +5,7 @@ metadata:
   namespace: litmus
 spec:
   schedule:
-    repeat:
-      properties:
-         #format should be like "10m" or "2h" accordingly for minutes or hours
-        minChaosInterval: "<chaos-schedule-interval>"  
+    now: true 
   engineTemplateSpec:
     engineState: active
     appinfo:

--- a/install/resources/testing-chaos/scripts/fault-test.py
+++ b/install/resources/testing-chaos/scripts/fault-test.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python3
+from subprocess import run
+from subprocess import PIPE
+import json
+from time import sleep
+from sys import argv
+
+litmus_ns = ""
+prometheus_ns = ""
+prometheus_scrape_interval = 0
+prometheus_alerts_endpoint = ""
+
+def get_cmd_output(cmd:str) -> (str):
+  cmd = cmd.split(" ")
+  return run(cmd, stdout=PIPE).stdout.decode("utf-8")
+
+def get_alerts_endpoint(prometheus_ns: str) -> (str):
+  global prometheus_alerts_endpoint
+  if(prometheus_alerts_endpoint == ""):
+    prometheus_route = get_cmd_output(
+        "oc get route -n" + prometheus_ns).split("\n")[1].split()[1]
+    prometheus_alerts_endpoint = prometheus_route + "/api/v1/alerts"
+  return prometheus_alerts_endpoint
+
+def initialise_test_args(args: list):
+  global litmus_ns
+  global prometheus_ns
+  global prometheus_scrape_interval
+  global prometheus_alerts_endpoint
+
+  litmus_ns = args[0] if len(args) > 0 else "litmus"
+  prometheus_ns = args[1] if len(
+      args) > 1 else "managed-services-monitoring-prometheus"
+  prometheus_scrape_interval = int(args[2]) if len(args) > 2 else 30
+  prometheus_alerts_endpoint = get_alerts_endpoint(prometheus_ns)
+
+def get_engine_names(litmus_ns:str) -> (list):
+  names = []
+  engines = get_cmd_output("oc get chaosengine -n " + litmus_ns).split("\n")[1:-1]
+  for engine in engines:
+    names.append(engine.split()[0])
+  return names
+
+def is_engine_complete(name:str) -> (bool):
+  engine_json = json.loads(get_cmd_output("oc get chaosengine " + name + " -n litmus -o json"))
+  experiments = engine_json["status"]["experiments"]
+  for experiment in experiments:
+    if(experiment["status"] != "Completed"):
+      return False
+  return True
+
+def is_chaos_complete(engines:list) -> (bool):
+  for engine in engines:
+    completed = is_engine_complete(engine)
+    if(completed != True):
+      return False
+  return True
+
+def filter_critical_alerts(alerts:list) -> (list):
+  critical_alerts = []
+  for alert in alerts:
+    if(alert["labels"]["severity"] == "critical"):
+      critical_alerts.append(alert)
+  return critical_alerts  
+
+def get_all_alerts(prometheus_alerts_endpoint:str) -> (list): 
+  prometheus_json = json.loads(get_cmd_output("curl -s " + prometheus_alerts_endpoint))
+  return prometheus_json["data"]["alerts"]
+
+def get_critical_alerts() -> (list):
+  print("Fetching critical alerts...")
+  alerts = get_all_alerts(get_alerts_endpoint(prometheus_ns))
+  if(len(alerts) == 0):
+    return []
+  return filter_critical_alerts(alerts)
+
+def watch_alerts() -> (list):
+  experiment_complete = is_chaos_complete(get_engine_names(litmus_ns))
+  critical_alerts = []
+  while(experiment_complete == False):
+    print("Waiting {} seconds for next Prometheus scrape interval".format(prometheus_scrape_interval))
+    sleep(prometheus_scrape_interval)
+    new_alerts = get_critical_alerts()
+    print("Alerts scraped. Critical alerts found: {}.".format(new_alerts))
+    critical_alerts.extend(new_alerts)
+    experiment_complete = is_chaos_complete(get_engine_names(litmus_ns))
+  return critical_alerts
+
+def fail_test(critical_alerts:list): 
+  print("FAIL: Critical alerts found:\n")
+  print(critical_alerts)
+  exit(1)
+
+def pass_test():
+  print("PASS: No critical alerts found")
+  exit(0)
+
+def main():
+  initialise_test_args(argv[1:])
+
+  chaos_engines = get_engine_names(litmus_ns)
+  if(len(chaos_engines) == 0):
+    print("PASS: No chaosengines found")
+    exit(0)
+
+  critical_alerts = watch_alerts()
+
+  if(len(critical_alerts) > 0):
+    fail_test(critical_alerts)
+  pass_test()
+  
+if __name__== "__main__":
+  main()


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What
https://issues.redhat.com/browse/MGDSTRM-544
Add script to check for critical alerts when chaos experiments are running.

<!-- Why these changes are required -->
## Why
Validate chaos experiments being run

<!-- How this PR implements these changes  -->
## How
- Adds test script that polls prometheus for critical alerts firing when chaosschedules are run.
- Updates make targets to add test script

## Verification:
```
cd install/resources/testing-chaos
make all
```