### PR TITLE
"MGDSTRM-578,MGDSTRM-584:SLI recording rules to SLI dashboard and ale…

### DIFF
--- a/install/resources/monitoring-cluster/dashboards/strimzi-kafka-slis.yaml
+++ b/install/resources/monitoring-cluster/dashboards/strimzi-kafka-slis.yaml
@@ -76,49 +76,31 @@ spec:
       "links": [],
       "panels": [
         {
-          "content": "\n# Availability (7 days)\n\n- Kafka Availability\n  - Based on at least 1 kafka borker pod being in a ready state\n- Zookeeper Availability\n  - Based on at least 1 zookeeper pod being in a ready state\n\n\n\n",
+          "cacheTimeout": null,
+          "colorBackground": false,
+          "colorValue": true,
+          "colors": [
+            "#d44a3a",
+            "rgba(237, 129, 40, 0.89)",
+            "#299c46"
+          ],
           "datasource": "${DS_PROMETHEUS}",
+          "description": "kafka producer request budget error",
+          "format": "percentunit",
+          "gauge": {
+            "maxValue": 100,
+            "minValue": 0,
+            "show": false,
+            "thresholdLabels": false,
+            "thresholdMarkers": true
+          },
           "gridPos": {
-            "h": 10,
-            "w": 4,
+            "h": 5,
+            "w": 6,
             "x": 0,
-            "y": 0
+            "y": 5
           },
-          "id": 53,
-          "mode": "markdown",
-          "options": {},
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "",
-          "transparent": true,
-          "type": "text"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "${DS_PROMETHEUS}",
-          "decimals": 3,
-          "format": "percentunit",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 4,
-            "y": 0
-          },
-          "id": 35,
+          "id": 5,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -136,6 +118,7 @@ spec:
           "nullPointMode": "connected",
           "nullText": null,
           "options": {},
+          "pluginVersion": "6.5.1",
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -158,18 +141,17 @@ spec:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg_over_time((absent(kube_namespace_status_phase{namespace=\"$kubernetes_namespace\"}) or max by(namespace) (kube_pod_status_ready{namespace=\"$kubernetes_namespace\", condition=\"true\", pod=~\".*kafka-[0-9]+.*\"}) or (0 * max by(namespace) (sum_over_time(kube_pod_status_ready{namespace=\"$kubernetes_namespace\", condition=\"true\", pod=~\".*kafka-[0-9]+.*\"}[7d]))))[7d:1m])",
-              "format": "time_series",
+              "expr": "1 -\nsum(increase(kafka_server_brokertopicmetrics_failed_produce_requests_total{namespace=\"$kubernetes_namespace\"}[28d]))\n/\nsum(increase(kafka_server_brokertopicmetrics_total_produce_requests_total{namespace=\"$kubernetes_namespace\"}[28d]))\n",
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "thresholds": "",
+          "thresholds": "0.99,0.995",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Kafka Availability",
+          "title": "Producer Availability (28d)",
           "type": "singlestat",
-          "valueFontSize": "80%",
+          "valueFontSize": "120%",
           "valueMaps": [
             {
               "op": "=",
@@ -182,20 +164,21 @@ spec:
         {
           "aliasColors": {},
           "bars": false,
+          "cacheTimeout": null,
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_PROMETHEUS}",
-          "fill": 1,
+          "description": "kafka producer request budget error",
+          "fill": 10,
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 17,
-            "x": 7,
-            "y": 0
+            "w": 18,
+            "x": 6,
+            "y": 5
           },
           "hiddenSeries": false,
-          "id": 44,
-          "interval": "",
+          "id": 6,
           "legend": {
             "avg": false,
             "current": false,
@@ -206,12 +189,14 @@ spec:
             "values": false
           },
           "lines": true,
-          "linewidth": 1,
+          "linewidth": 0,
+          "links": [],
           "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
           "percentage": false,
+          "pluginVersion": "6.5.1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -221,17 +206,18 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(kube_pod_status_ready{namespace=\"$kubernetes_namespace\", condition=\"true\", pod=~\".*kafka-[0-9]+.*\"})",
-              "format": "time_series",
-              "legendFormat": "Number of pods ready",
+              "expr": "(\n  (\n    1 -\n    sum(increase(kafka_server_brokertopicmetrics_failed_produce_requests_total{namespace=\"$kubernetes_namespace\"}[28d]))\n    /\n    sum(increase(kafka_server_brokertopicmetrics_total_produce_requests_total{namespace=\"$kubernetes_namespace\"}[28d]))\n  ) - 0.99\n)\n/ \n(1 - 0.99)",
+              "instant": false,
+              "intervalFactor": 10, 
+              "legendFormat": "errorbudget",
               "refId": "A"
             }
           ],
           "thresholds": [],
-          "timeFrom": "7d",
+          "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Kafka pods ready",
+          "title": "Producer Error Budget (28d)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -247,12 +233,12 @@ spec:
           },
           "yaxes": [
             {
-              "decimals": 0,
-              "format": "short",
+              "decimals": null,
+              "format": "percentunit",
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": "0",
+              "min": null,
               "show": true
             },
             {
@@ -261,7 +247,7 @@ spec:
               "logBase": 1,
               "max": null,
               "min": null,
-              "show": true
+              "show": false
             }
           ],
           "yaxis": {
@@ -272,100 +258,14 @@ spec:
         {
           "cacheTimeout": null,
           "colorBackground": false,
-          "colorValue": false,
+          "colorValue": true,
           "colors": [
-            "#299c46",
+            "#d44a3a",
             "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
+            "#299c46"
           ],
           "datasource": "${DS_PROMETHEUS}",
-          "format": "none",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 2,
-            "w": 3,
-            "x": 4,
-            "y": 3
-          },
-          "id": 33,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false,
-            "ymax": null,
-            "ymin": null
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "sum(kube_pod_status_ready{namespace=\"$kubernetes_namespace\", condition=\"true\", pod=~\".*kafka-[0-9]+.*\"})",
-              "format": "time_series",
-              "instant": true,
-              "legendFormat": "",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Kafka pods ready",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "${DS_PROMETHEUS}",
-          "decimals": 3,
+          "description": "kafka fetch request budget error",
           "format": "percentunit",
           "gauge": {
             "maxValue": 100,
@@ -375,12 +275,12 @@ spec:
             "thresholdMarkers": true
           },
           "gridPos": {
-            "h": 3,
-            "w": 3,
-            "x": 4,
-            "y": 5
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 10
           },
-          "id": 51,
+          "id": 7,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -398,6 +298,7 @@ spec:
           "nullPointMode": "connected",
           "nullText": null,
           "options": {},
+          "pluginVersion": "6.5.1",
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -420,18 +321,17 @@ spec:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg_over_time((absent(kube_namespace_status_phase{namespace=\"$kubernetes_namespace\"}) or max by(namespace) (kube_pod_status_ready{namespace=\"$kubernetes_namespace\", condition=\"true\", pod=~\".*zookeeper-[0-9]+.*\"}) or (0 * max by(namespace) (sum_over_time(kube_pod_status_ready{namespace=\"$kubernetes_namespace\", condition=\"true\", pod=~\".*zookeeper-[0-9]+.*\"}[7d]))))[7d:1m])",
-              "format": "time_series",
+              "expr": "1 -\nsum(increase(kafka_server_brokertopicmetrics_failed_fetch_requests_total{namespace=\"$kubernetes_namespace\"}[28d]))\n/\nsum(increase(kafka_server_brokertopicmetrics_total_fetch_requests_total{namespace=\"$kubernetes_namespace\"}[28d]))\n",
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "thresholds": "",
+          "thresholds": "0.99,0.995",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Zookeeper Availability",
+          "title": "Fetch Availability (28d)",
           "type": "singlestat",
-          "valueFontSize": "80%",
+          "valueFontSize": "120%",
           "valueMaps": [
             {
               "op": "=",
@@ -444,20 +344,21 @@ spec:
         {
           "aliasColors": {},
           "bars": false,
+          "cacheTimeout": null,
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_PROMETHEUS}",
-          "fill": 1,
+          "description": "kafka producer fetch budget error",
+          "fill": 10,
           "fillGradient": 0,
           "gridPos": {
             "h": 5,
-            "w": 17,
-            "x": 7,
-            "y": 5
+            "w": 18,
+            "x": 6,
+            "y": 10
           },
           "hiddenSeries": false,
-          "id": 45,
-          "interval": "",
+          "id": 8,
           "legend": {
             "avg": false,
             "current": false,
@@ -468,12 +369,14 @@ spec:
             "values": false
           },
           "lines": true,
-          "linewidth": 1,
+          "linewidth": 0,
+          "links": [],
           "nullPointMode": "null",
           "options": {
             "dataLinks": []
           },
           "percentage": false,
+          "pluginVersion": "6.5.1",
           "pointradius": 2,
           "points": false,
           "renderer": "flot",
@@ -483,17 +386,18 @@ spec:
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(kube_pod_status_ready{namespace=\"$kubernetes_namespace\", condition=\"true\", pod=~\".*zookeeper-[0-9]+.*\"})",
-              "format": "time_series",
-              "legendFormat": "Number of pods ready",
+              "expr": "(\n  (\n    1 -\n    sum(increase(kafka_server_brokertopicmetrics_failed_fetch_requests_total{namespace=\"$kubernetes_namespace\"}[28d]))\n    /\n    sum(increase(kafka_server_brokertopicmetrics_total_fetch_requests_total{namespace=\"$kubernetes_namespace\"}[28d]))\n  ) - 0.99\n)\n/ \n(1 - 0.99)",
+              "instant": false,
+              "intervalFactor": 10, 
+              "legendFormat": "errorbudget",
               "refId": "A"
             }
           ],
           "thresholds": [],
-          "timeFrom": "7d",
+          "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Zookeeper pods ready",
+          "title": "Fetch Error Budget (28d)",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -509,12 +413,12 @@ spec:
           },
           "yaxes": [
             {
-              "decimals": 0,
-              "format": "short",
+              "decimals": null,
+              "format": "percentunit",
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": "0",
+              "min": null,
               "show": true
             },
             {
@@ -523,7 +427,7 @@ spec:
               "logBase": 1,
               "max": null,
               "min": null,
-              "show": true
+              "show": false
             }
           ],
           "yaxis": {
@@ -534,14 +438,15 @@ spec:
         {
           "cacheTimeout": null,
           "colorBackground": false,
-          "colorValue": false,
+          "colorValue": true,
           "colors": [
-            "#299c46",
+            "#d44a3a",
             "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
+            "#299c46"
           ],
           "datasource": "${DS_PROMETHEUS}",
-          "format": "none",
+          "description": "kafka connection budget error",
+          "format": "percentunit",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,
@@ -550,12 +455,12 @@ spec:
             "thresholdMarkers": true
           },
           "gridPos": {
-            "h": 2,
-            "w": 3,
-            "x": 4,
-            "y": 8
+            "h": 5,
+            "w": 6,
+            "x": 0,
+            "y": 15
           },
-          "id": 50,
+          "id": 9,
           "interval": null,
           "links": [],
           "mappingType": 1,
@@ -573,6 +478,7 @@ spec:
           "nullPointMode": "connected",
           "nullText": null,
           "options": {},
+          "pluginVersion": "6.5.1",
           "postfix": "",
           "postfixFontSize": "50%",
           "prefix": "",
@@ -595,19 +501,17 @@ spec:
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(kube_pod_status_ready{namespace=\"$kubernetes_namespace\", condition=\"true\", pod=~\".*zookeeper-[0-9]+.*\"})",
-              "format": "time_series",
-              "instant": true,
+              "expr": "1 -\nsum(increase(haproxy_server_connection_errors_total{namespace=\"$kubernetes_namespace\", condition=\"true\", route=~\".+-kafka-([0-9]+|bootstrap)$\"}[28d]))\n/\nsum(increase(haproxy_server_connections_total{namespace=\"$kubernetes_namespace\", condition=\"true\", route=~\".+-kafka-([0-9]+|bootstrap)$\"}[28d]))\n",
               "legendFormat": "",
               "refId": "A"
             }
           ],
-          "thresholds": "",
+          "thresholds": "0.99,0.995",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Zookeeper pods ready",
+          "title": "Connection Availability (28d)",
           "type": "singlestat",
-          "valueFontSize": "80%",
+          "valueFontSize": "120%",
           "valueMaps": [
             {
               "op": "=",
@@ -616,6 +520,100 @@ spec:
             }
           ],
           "valueName": "current"
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "cacheTimeout": null,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_PROMETHEUS}",
+          "description": "kafka connection budget error",
+          "fill": 10,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 5,
+            "w": 18,
+            "x": 6,
+            "y": 15
+          },
+          "hiddenSeries": false,
+          "id": 10,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 0,
+          "links": [],
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pluginVersion": "6.5.1",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "(\n  (\n    1 -\n    sum(increase(haproxy_server_connection_errors_total{namespace=\"$kubernetes_namespace\", condition=\"true\", route=~\".+-kafka-([0-9]+|bootstrap)$\"}[28d]))\n    /\n    sum(increase(haproxy_server_connections_total{namespace=\"$kubernetes_namespace\", condition=\"true\", route=~\".+-kafka-([0-9]+|bootstrap)$\"}[28d]))\n  ) - 0.99\n)\n/ \n(1 - 0.99)",
+              "instant": false,
+              "intervalFactor": 10, 
+              "legendFormat": "errorbudget",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Connection Error Budget (28d)",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "decimals": null,
+              "format": "percentunit",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
         },
         {
           "cacheTimeout": null,
@@ -640,7 +638,7 @@ spec:
             "h": 5,
             "w": 6,
             "x": 0,
-            "y": 10
+            "y": 20
           },
           "id": 37,
           "interval": null,
@@ -717,7 +715,7 @@ spec:
             "h": 5,
             "w": 18,
             "x": 6,
-            "y": 10
+            "y": 20
           },
           "hiddenSeries": false,
           "id": 46,
@@ -817,7 +815,7 @@ spec:
             "h": 5,
             "w": 6,
             "x": 0,
-            "y": 15
+            "y": 25
           },
           "id": 39,
           "interval": null,
@@ -892,7 +890,7 @@ spec:
             "h": 5,
             "w": 18,
             "x": 6,
-            "y": 15
+            "y": 25
           },
           "hiddenSeries": false,
           "id": 47,
@@ -990,7 +988,7 @@ spec:
             "h": 5,
             "w": 6,
             "x": 0,
-            "y": 20
+            "y": 30
           },
           "id": 43,
           "interval": null,
@@ -1065,7 +1063,7 @@ spec:
             "h": 5,
             "w": 18,
             "x": 6,
-            "y": 20
+            "y": 30
           },
           "hiddenSeries": false,
           "id": 48,
@@ -1163,7 +1161,7 @@ spec:
             "h": 5,
             "w": 6,
             "x": 0,
-            "y": 25
+            "y": 35
           },
           "id": 41,
           "interval": null,
@@ -1238,7 +1236,7 @@ spec:
             "h": 5,
             "w": 18,
             "x": 6,
-            "y": 25
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 49,
@@ -1337,7 +1335,7 @@ spec:
             "h": 5,
             "w": 6,
             "x": 0,
-            "y": 30
+            "y": 40
           },
           "id": 4,
           "interval": null,
@@ -1412,7 +1410,7 @@ spec:
             "h": 5,
             "w": 18,
             "x": 6,
-            "y": 30
+            "y": 40
           },
           "hiddenSeries": false,
           "id": 28,
@@ -1451,525 +1449,6 @@ spec:
           "timeRegions": [],
           "timeShift": null,
           "title": "Quality - Partitions Online",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "Define the latency for main protocol requests sent by producer and consumer, even if they are heavily influenced by how the clients are configured (i.e. producer “acks”).",
-          "format": "ms",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 0,
-            "y": 35
-          },
-          "id": 24,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false,
-            "ymax": null,
-            "ymin": null
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "max(kafka_network_requestmetrics_total_time_ms{quantile=\"0.95\", request=\"Produce\", namespace=\"$kubernetes_namespace\"})",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Latency - 95% of producer requests < x ms",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "cacheTimeout": null,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "Define the latency for main protocol requests sent by producer and consumer, even if they are heavily influenced by how the clients are configured (i.e. producer “acks”).",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 5,
-            "w": 18,
-            "x": 6,
-            "y": 35
-          },
-          "hiddenSeries": false,
-          "id": 29,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "max(kafka_network_requestmetrics_total_time_ms{quantile=\"0.95\", request=\"Produce\", namespace=\"$kubernetes_namespace\"})",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Latency - 95% of producer requests < x ms",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "Define the latency for main protocol requests sent by producer and consumer, even if they are heavily influenced by how the clients are configured (i.e. producer “acks”).",
-          "format": "ms",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 0,
-            "y": 40
-          },
-          "id": 25,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false,
-            "ymax": null,
-            "ymin": null
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "max(kafka_network_requestmetrics_total_time_ms{quantile=\"0.95\", request=\"FetchConsumer\", namespace=\"$kubernetes_namespace\"})",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Latency - 95% of fetch consumer requests < x ms",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "cacheTimeout": null,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "Define the latency for main protocol requests sent by producer and consumer, even if they are heavily influenced by how the clients are configured (i.e. producer “acks”).",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 5,
-            "w": 18,
-            "x": 6,
-            "y": 40
-          },
-          "hiddenSeries": false,
-          "id": 30,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "max(kafka_network_requestmetrics_total_time_ms{quantile=\"0.95\", request=\"FetchConsumer\", namespace=\"$kubernetes_namespace\"})",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Latency - 95% of fetch consumer requests < x ms",
-          "tooltip": {
-            "shared": true,
-            "sort": 0,
-            "value_type": "individual"
-          },
-          "type": "graph",
-          "xaxis": {
-            "buckets": null,
-            "mode": "time",
-            "name": null,
-            "show": true,
-            "values": []
-          },
-          "yaxes": [
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": "0",
-              "show": true
-            },
-            {
-              "format": "short",
-              "label": null,
-              "logBase": 1,
-              "max": null,
-              "min": null,
-              "show": true
-            }
-          ],
-          "yaxis": {
-            "align": false,
-            "alignLevel": null
-          }
-        },
-        {
-          "cacheTimeout": null,
-          "colorBackground": false,
-          "colorValue": false,
-          "colors": [
-            "#299c46",
-            "rgba(237, 129, 40, 0.89)",
-            "#d44a3a"
-          ],
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "Define the latency for main protocol requests sent by producer and consumer, even if they are heavily influenced by how the clients are configured (i.e. producer “acks”).",
-          "format": "ms",
-          "gauge": {
-            "maxValue": 100,
-            "minValue": 0,
-            "show": false,
-            "thresholdLabels": false,
-            "thresholdMarkers": true
-          },
-          "gridPos": {
-            "h": 5,
-            "w": 6,
-            "x": 0,
-            "y": 45
-          },
-          "id": 26,
-          "interval": null,
-          "links": [],
-          "mappingType": 1,
-          "mappingTypes": [
-            {
-              "name": "value to text",
-              "value": 1
-            },
-            {
-              "name": "range to text",
-              "value": 2
-            }
-          ],
-          "maxDataPoints": 100,
-          "nullPointMode": "connected",
-          "nullText": null,
-          "options": {},
-          "postfix": "",
-          "postfixFontSize": "50%",
-          "prefix": "",
-          "prefixFontSize": "50%",
-          "rangeMaps": [
-            {
-              "from": "null",
-              "text": "N/A",
-              "to": "null"
-            }
-          ],
-          "sparkline": {
-            "fillColor": "rgba(31, 118, 189, 0.18)",
-            "full": false,
-            "lineColor": "rgb(31, 120, 193)",
-            "show": false,
-            "ymax": null,
-            "ymin": null
-          },
-          "tableColumn": "",
-          "targets": [
-            {
-              "expr": "max(kafka_network_requestmetrics_total_time_ms{quantile=\"0.95\", request=\"FetchFollower\", namespace=\"$kubernetes_namespace\"})",
-              "refId": "A"
-            }
-          ],
-          "thresholds": "",
-          "timeFrom": null,
-          "timeShift": null,
-          "title": "Latency - 95% of fetch follower requests < x ms",
-          "type": "singlestat",
-          "valueFontSize": "80%",
-          "valueMaps": [
-            {
-              "op": "=",
-              "text": "N/A",
-              "value": "null"
-            }
-          ],
-          "valueName": "current"
-        },
-        {
-          "aliasColors": {},
-          "bars": false,
-          "cacheTimeout": null,
-          "dashLength": 10,
-          "dashes": false,
-          "datasource": "${DS_PROMETHEUS}",
-          "description": "Define the latency for main protocol requests sent by producer and consumer, even if they are heavily influenced by how the clients are configured (i.e. producer “acks”).",
-          "fill": 1,
-          "fillGradient": 0,
-          "gridPos": {
-            "h": 5,
-            "w": 18,
-            "x": 6,
-            "y": 45
-          },
-          "hiddenSeries": false,
-          "id": 31,
-          "legend": {
-            "avg": false,
-            "current": false,
-            "max": false,
-            "min": false,
-            "show": true,
-            "total": false,
-            "values": false
-          },
-          "lines": true,
-          "linewidth": 1,
-          "links": [],
-          "nullPointMode": "null",
-          "options": {
-            "dataLinks": []
-          },
-          "percentage": false,
-          "pointradius": 2,
-          "points": false,
-          "renderer": "flot",
-          "seriesOverrides": [],
-          "spaceLength": 10,
-          "stack": false,
-          "steppedLine": false,
-          "targets": [
-            {
-              "expr": "max(kafka_network_requestmetrics_total_time_ms{quantile=\"0.95\", request=\"FetchFollower\", namespace=\"$kubernetes_namespace\"})",
-              "refId": "A"
-            }
-          ],
-          "thresholds": [],
-          "timeFrom": null,
-          "timeRegions": [],
-          "timeShift": null,
-          "title": "Latency - 95% of fetch follower requests < x ms",
           "tooltip": {
             "shared": true,
             "sort": 0,

--- a/install/resources/monitoring-cluster/prometheus/prometheus-rules-cr.yaml
+++ b/install/resources/monitoring-cluster/prometheus/prometheus-rules-cr.yaml
@@ -1,0 +1,8 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    app: strimzi
+  name: kafka-prometheus-rules
+  namespace: <namespace>
+spec:

--- a/install/resources/monitoring-cluster/prometheus/prometheus-rules-groups.yaml
+++ b/install/resources/monitoring-cluster/prometheus/prometheus-rules-groups.yaml
@@ -1,0 +1,415 @@
+groups:
+- name: kafka-api-slo
+  rules:
+  - alert: ErrorBudgetBurn_ProduceRequests_5mS1hL
+    annotations:
+      message: 'High error budget burn for failed produce requests during 5m short window, 1h long window. (current value: {{ $value }})'
+    expr: |
+      sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate5m) > (14.40 * (1-0.99000))
+      and
+      sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1h) > (14.40 * (1-0.99000))
+    for: 2m
+    labels:
+      severity: critical
+  - alert: ErrorBudgetBurn_ProduceRequests_30mS6hL
+    annotations:
+      message: 'High error budget burn for failed produce requests during 30m short window, 6h long window. (current value: {{ $value }})'
+    expr: |
+      sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate30m) > (6.00 * (1-0.99000))
+      and
+      sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h) > (6.00 * (1-0.99000))
+    for: 15m
+    labels:
+      severity: critical
+  - alert: ErrorBudgetBurn_ProduceRequests_2hS1dL
+    annotations:
+      message: 'High error budget burn for failed produce requests during 2h short window, 1d long window. (current value: {{ $value }})'
+    expr: |
+      sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate2h) > (3.00 * (1-0.99000))
+      and
+      sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1d) > (3.00 * (1-0.99000))
+    for: 1h
+    labels:
+      severity: warning
+  - alert: ErrorBudgetBurn_ProduceRequests_6hS3dL
+    annotations:
+      message: 'High error budget burn for failed produce requests during 6h short window, 3d long window. (current value: {{ $value }})'
+    expr: |
+      sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h) > (1.00 * (1-0.99000))
+      and
+      sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate3d) > (1.00 * (1-0.99000))
+    for: 3h
+    labels:
+      severity: warning
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total[1d]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total[1d]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1d
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total[1h]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total[1h]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1h
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total[2h]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total[2h]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate2h
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total[30m]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total[30m]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate30m
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total[3d]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total[3d]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate3d
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total[5m]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total[5m]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate5m
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_produce_requests_total[6h]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_produce_requests_total[6h]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h
+  - alert: ErrorBudgetBurn_FetchRequests
+    annotations:
+      message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
+    expr: |
+      sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate5m) > (14.40 * (1-0.99000))
+      and
+      sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1h) > (14.40 * (1-0.99000))
+    for: 2m
+    labels:
+      severity: critical
+  - alert: ErrorBudgetBurn_FetchRequests
+    annotations:
+      message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
+    expr: |
+      sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate30m) > (6.00 * (1-0.99000))
+      and
+      sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h) > (6.00 * (1-0.99000))
+    for: 15m
+    labels:
+      severity: critical
+  - alert: ErrorBudgetBurn_FetchRequests
+    annotations:
+      message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
+    expr: |
+      sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate2h) > (3.00 * (1-0.99000))
+      and
+      sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1d) > (3.00 * (1-0.99000))
+    for: 1h
+    labels:
+      severity: warning
+  - alert: ErrorBudgetBurn_FetchRequests
+    annotations:
+      message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
+    expr: |
+      sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h) > (1.00 * (1-0.99000))
+      and
+      sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate3d) > (1.00 * (1-0.99000))
+    for: 3h
+    labels:
+      severity: warning
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total[1d]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total[1d]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1d
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total[1h]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total[1h]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1h
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total[2h]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total[2h]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate2h
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total[30m]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total[30m]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate30m
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total[3d]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total[3d]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate3d
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total[5m]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total[5m]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate5m
+  - expr: |
+      sum(rate(kafka_server_brokertopicmetrics_failed_fetch_requests_total[6h]))
+      /
+      sum(rate(kafka_server_brokertopicmetrics_total_fetch_requests_total[6h]))
+    labels:
+    record: kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h
+  - alert: ErrorBudgetBurn_Connections
+    annotations:
+      message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
+    expr: |
+      sum(haproxy_server_connection_errors_total:burnrate5m) > (14.40 * (1-0.99000))
+      and
+      sum(haproxy_server_connection_errors_total:burnrate1h) > (14.40 * (1-0.99000))
+    for: 2m
+    labels:
+      severity: critical
+  - alert: ErrorBudgetBurn_Connections
+    annotations:
+      message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
+    expr: |
+      sum(haproxy_server_connection_errors_total:burnrate30m) > (6.00 * (1-0.99000))
+      and
+      sum(haproxy_server_connection_errors_total:burnrate6h) > (6.00 * (1-0.99000))
+    for: 15m
+    labels:
+      severity: critical
+  - alert: ErrorBudgetBurn_Connections
+    annotations:
+      message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
+    expr: |
+      sum(haproxy_server_connection_errors_total:burnrate2h) > (3.00 * (1-0.99000))
+      and
+      sum(haproxy_server_connection_errors_total:burnrate1d) > (3.00 * (1-0.99000))
+    for: 1h
+    labels:
+      severity: warning
+  - alert: ErrorBudgetBurn_Connections
+    annotations:
+      message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
+    expr: |
+      sum(haproxy_server_connection_errors_total:burnrate6h) > (1.00 * (1-0.99000))
+      and
+      sum(haproxy_server_connection_errors_total:burnrate3d) > (1.00 * (1-0.99000))
+    for: 3h
+    labels:
+      severity: warning
+  - expr: |
+      sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[1d]))
+      /
+      sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[1d]))
+    labels:
+    record: haproxy_server_connection_errors_total:burnrate1d
+  - expr: |
+      sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[1h]))
+      /
+      sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[1h]))
+    labels:
+    record: haproxy_server_connection_errors_total:burnrate1h
+  - expr: |
+      sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[2h]))
+      /
+      sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[2h]))
+    labels:
+    record: haproxy_server_connection_errors_total:burnrate2h
+  - expr: |
+      sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[30m]))
+      /
+      sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[30m]))
+    labels:
+    record: haproxy_server_connection_errors_total:burnrate30m
+  - expr: |
+      sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[3d]))
+      /
+      sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[3d]))
+    labels:
+    record: haproxy_server_connection_errors_total:burnrate3d
+  - expr: |
+      sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[5m]))
+      /
+      sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[5m]))
+    labels:
+    record: haproxy_server_connection_errors_total:burnrate5m
+  - expr: |
+      sum(rate(haproxy_server_connection_errors_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[6h]))
+      /
+      sum(rate(haproxy_server_connections_total{route=~".+-kafka-([0-9]+|bootstrap)$"}[6h]))
+    labels:
+    record: haproxy_server_connection_errors_total:burnrate6h
+- name: kafka
+  rules:
+  - alert: KafkaPersistentVolumeFillingUp
+    expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-([0-9]+)?-(.+)-kafka-[0-9]+"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"data-([0-9]+)?-(.+)-kafka-[0-9]+"} < 0.03
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: 'Kafka Broker PersistentVolume is filling up.'
+      description: 'The Kafka Broker PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.'
+  - alert: KafkaPersistentVolumeFillingUp
+    expr: (kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-([0-9]+)?-(.+)-kafka-[0-9]+"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"data-([0-9]+)?-(.+)-kafka-[0-9]+"} < 0.15) and predict_linear(kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-([0-9]+)?-(.+)-kafka-[0-9]+"}[6h], 4 * 24 * 3600) < 0
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Kafka Broker PersistentVolume is filling up.'
+      description: 'Based on recent sampling, the Kafka Broker PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available.'
+  - alert: UnderReplicatedPartitions
+    expr: kafka_server_replicamanager_under_replicated_partitions > 0
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Kafka under replicated partitions'
+      description: 'There are {{ $value }} under replicated partitions on {{ $labels.kubernetes_pod_name }}'
+  - alert: AbnormalControllerState
+    expr: sum(kafka_controller_kafkacontroller_active_controller_count) != 1
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Kafka abnormal controller state'
+      description: 'There are {{ $value }} active controllers in the cluster'
+  - alert: OfflinePartitions
+    expr: sum(kafka_controller_kafkacontroller_offline_partitions_count) > 0
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Kafka offline partitions'
+      description: 'One or more partitions have no leader'
+  - alert: UnderMinIsrPartitionCount
+    expr: kafka_server_replicamanager_under_min_isr_partition_count > 0
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Kafka under min ISR partitions'
+      description: 'There are {{ $value }} partitions under the min ISR on {{ $labels.kubernetes_pod_name }}'
+  - alert: OfflineLogDirectoryCount
+    expr: kafka_log_logmanager_offline_log_directory_count > 0
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Kafka offline log directories'
+      description: 'There are {{ $value }} offline log directories on {{ $labels.kubernetes_pod_name }}'
+  - alert: ScrapeProblem
+    expr: up{kubernetes_namespace!~"openshift-.+",kubernetes_pod_name=~".+-kafka-[0-9]+"} == 0
+    for: 3m
+    labels:
+      severity: major
+    annotations:
+      summary: 'Prometheus unable to scrape metrics from {{ $labels.kubernetes_pod_name }}/{{ $labels.instance }}'
+      description: 'Prometheus was unable to scrape metrics from {{ $labels.kubernetes_pod_name }}/{{ $labels.instance }} for more than 3 minutes'
+  - alert: ClusterOperatorContainerDown
+    expr: count((container_last_seen{container="strimzi-cluster-operator"} > (time() - 90))) < 1 or absent(container_last_seen{container="strimzi-cluster-operator"})
+    for: 1m
+    labels:
+      severity: major
+    annotations:
+      summary: 'Cluster Operator down'
+      description: 'The Cluster Operator has been down for longer than 90 seconds'
+  - alert: KafkaBrokerContainersDown
+    expr: absent(container_last_seen{container="kafka",pod=~".+-kafka-[0-9]+"})
+    for: 3m
+    labels:
+      severity: major
+    annotations:
+      summary: 'All `kafka` containers down or in CrashLookBackOff status'
+      description: 'All `kafka` containers have been down or in CrashLookBackOff status for 3 minutes'
+  - alert: KafkaContainerRestartedInTheLast5Minutes
+    expr: count(count_over_time(container_last_seen{container="kafka"}[5m])) > 2 * count(container_last_seen{container="kafka",pod=~".+-kafka-[0-9]+"})
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: 'One or more Kafka containers restarted too often'
+      description: 'One or more Kafka containers were restarted too often within the last 5 minutes'
+- name: zookeeper
+  rules:
+  - alert: AvgRequestLatency
+    expr: zookeeper_avg_request_latency > 10
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Zookeeper average request latency'
+      description: 'The average request latency is {{ $value }} on {{ $labels.kubernetes_pod_name }}'
+  - alert: OutstandingRequests
+    expr: zookeeper_outstanding_requests > 10
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Zookeeper outstanding requests'
+      description: 'There are {{ $value }} outstanding requests on {{ $labels.kubernetes_pod_name }}'
+  - alert: ZookeeperPersistentVolumeFillingUp
+    expr: kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-(.+)-zookeeper-[0-9]+"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"data-(.+)-zookeeper-[0-9]+"} < 0.03
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: 'Zookeeper PersistentVolume is filling up.'
+      description: 'The Zookeeper PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.'
+  - alert: ZookeeperPersistentVolumeFillingUp
+    expr: (kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-(.+)-zookeeper-[0-9]+"} / kubelet_volume_stats_capacity_bytes{persistentvolumeclaim=~"data-(.+)-zookeeper-[0-9]+"} < 0.15) and predict_linear(kubelet_volume_stats_available_bytes{persistentvolumeclaim=~"data-(.+)-zookeeper-[0-9]+"}[6h], 4 * 24 * 3600) < 0
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Zookeeper PersistentVolume is filling up.'
+      description: 'Based on recent sampling, the Zookeeper PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available.'
+  - alert: ZookeeperContainerRestartedInTheLast5Minutes
+    expr: count(count_over_time(container_last_seen{container="zookeeper"}[5m])) > 2 * count(container_last_seen{container="zookeeper",pod=~".+-zookeeper-[0-9]+"})
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: 'One or more Zookeeper containers were restarted too often'
+      description: 'One or more Zookeeper containers were restarted too often within the last 5 minutes. This alert can be ignored when the Zookeeper cluster is scaling up'
+  - alert: ZookeeperContainersDown
+    expr: absent(container_last_seen{container="zookeeper",pod=~".+-zookeeper-[0-9]+"})
+    for: 3m
+    labels:
+      severity: major
+    annotations:
+      summary: 'All `zookeeper` containers in the Zookeeper pods down or in CrashLookBackOff status'
+      description: 'All `zookeeper` containers in the Zookeeper pods have been down or in CrashLookBackOff status for 3 minutes'
+- name: kafkaExporter
+  rules:
+  - alert: UnderReplicatedPartition
+    expr: kafka_topic_partition_under_replicated_partition > 0
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Topic has under-replicated partitions'
+      description: 'Topic  {{ $labels.topic }} has {{ $value }} under-replicated partition {{ $labels.partition }}'
+  - alert: TooLargeConsumerGroupLag
+    expr: kafka_consumergroup_lag > 1000
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'Consumer group lag is too big'
+      description: 'Consumer group {{ $labels.consumergroup}} lag is too big ({{ $value }}) on topic {{ $labels.topic }}/partition {{ $labels.partition }}'
+  - alert: NoMessageForTooLong
+    expr: changes(kafka_topic_partition_current_offset{topic!="__consumer_offsets"}[10m]) == 0
+    for: 10s
+    labels:
+      severity: warning
+    annotations:
+      summary: 'No message for 10 minutes'
+      description: 'There is no messages in topic {{ $labels.topic}}/partition {{ $labels.partition }} for 10 minutes'

--- a/install/resources/monitoring-cluster/prometheus/prometheus-rules-test.yaml
+++ b/install/resources/monitoring-cluster/prometheus/prometheus-rules-test.yaml
@@ -1,0 +1,103 @@
+# This is a list of rule files to consider for testing. Globs are supported.
+rule_files:
+  - prometheus-rules-groups.yaml
+
+# optional, default = 1m
+evaluation_interval: 1m
+
+# The order in which group names are listed below will be the order of evaluation of
+# rule groups (at a given evaluation time). The order is guaranteed only for the groups mentioned below.
+# All the groups need not be mentioned below.
+# group_eval_order:
+#   [ - <group_name> ]
+
+tests:
+    # 99% SLO, burn rate of just over 1.
+    # This means just over 1% of requests are errors over 6h i.e.
+    # - 7 failed requests per 600 total every minute for 6h
+    # - 0 failed requests thereafter
+    - interval: 1m
+      input_series:
+          - series: 'kafka_server_brokertopicmetrics_failed_produce_requests_total'
+            values: '0+7x360'
+          - series: 'kafka_server_brokertopicmetrics_total_produce_requests_total'
+            values: '0+600x360 216000+600x360'
+      alert_rule_test:
+          # Warning should fire after 6h short window.
+          - eval_time: 6h
+            alertname: ErrorBudgetBurn_ProduceRequests_6hS3dL
+            exp_alerts:
+                - exp_labels:
+                      severity: warning
+                  exp_annotations:
+                      message: "High error budget burn for failed produce requests during 6h short window, 3d long window. (current value: 0.011666666666666667)"
+          # No alerts after 6h with 0 failed requests
+          - eval_time: 12h
+            alertname: ErrorBudgetBurn_ProduceRequests_6hS3dL
+    # 99% SLO, burn rate of just over 3.
+    # This means just over 3% of requests are errors over 3h i.e.
+    # - 19 failed requests per 600 total every minute for 3h
+    # - 0 failed requests thereafter
+    - interval: 1m
+      input_series:
+          - series: 'kafka_server_brokertopicmetrics_failed_produce_requests_total'
+            values: '0+19x120'
+          - series: 'kafka_server_brokertopicmetrics_total_produce_requests_total'
+            values: '0+600x120 72000+600x120'
+      alert_rule_test:
+          # Warning should fire after 2h short window.
+          - eval_time: 2h
+            alertname: ErrorBudgetBurn_ProduceRequests_2hS1dL
+            exp_alerts:
+                - exp_labels:
+                      severity: warning
+                  exp_annotations:
+                      message: "High error budget burn for failed produce requests during 2h short window, 1d long window. (current value: 0.03166666666666667)"
+          # No alerts after 2h with 0 failed requests
+          - eval_time: 4h
+            alertname: ErrorBudgetBurn_ProduceRequests_2hS1dL     
+    # 99% SLO, burn rate of just over 6.
+    # This means just over 15% of requests are errors over 6h i.e.
+    # - 150 failed requests per 600 total every minute for 6h
+    # - 0 failed requests thereafter
+    - interval: 1m
+      input_series:
+          - series: 'kafka_server_brokertopicmetrics_failed_produce_requests_total'
+            values: '0+150x30'
+          - series: 'kafka_server_brokertopicmetrics_total_produce_requests_total'
+            values: '0+600x30 18000+600x30'
+      alert_rule_test:
+          # Warning should fire after 30m short window.
+          - eval_time: 30m
+            alertname: ErrorBudgetBurn_ProduceRequests_30mS6hL
+            exp_alerts:
+                - exp_labels:
+                      severity: critical
+                  exp_annotations:
+                      message: "High error budget burn for failed produce requests during 30m short window, 6h long window. (current value: 0.25)"
+          # No alerts after 1h30m with 0 failed requests
+          - eval_time: 1h30m
+            alertname: ErrorBudgetBurn_ProduceRequests_30mS6hL   
+    # 99% SLO, burn rate of just over 14.40.
+    # This means just over 14.4% of requests are errors over 14.40 i.e.
+    # - 87 failed requests per 600 total every minute for 1h
+    # - 0 failed requests thereafter
+    - interval: 1m
+      input_series:
+          - series: 'kafka_server_brokertopicmetrics_failed_produce_requests_total'
+            values: '0+87x5'
+          - series: 'kafka_server_brokertopicmetrics_total_produce_requests_total'
+            values: '0+600x5 30000+600x5'
+      alert_rule_test:
+          # Warning should fire after 5m short window.
+          - eval_time: 5m
+            alertname: ErrorBudgetBurn_ProduceRequests_5mS1hL
+            exp_alerts:
+                - exp_labels:
+                      severity: critical
+                  exp_annotations:
+                      message: "High error budget burn for failed produce requests during 5m short window, 1h long window. (current value: 0.145)"
+          # No alerts after 5m with 0 failed requests
+          - eval_time: 10m
+            alertname: ErrorBudgetBurn_ProduceRequests_5mS1hL                   
+    

--- a/install/resources/monitoring-cluster/prometheus/prometheus-rules.yaml
+++ b/install/resources/monitoring-cluster/prometheus/prometheus-rules.yaml
@@ -13,9 +13,9 @@ spec:
       annotations:
         message: 'High error budget burn for Failed Produce Requests (current value: {{ $value }})'
       expr: |
-        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate5m{}) > (14.40 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate5m{}) > (14.40 * (1-0.99000))
         and
-        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1h{}) > (14.40 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1h{}) > (14.40 * (1-0.99000))
       for: 2m
       labels:
         name: FailedProduceRequestsPerSec
@@ -24,9 +24,9 @@ spec:
       annotations:
         message: 'High error budget burn for Failed Produce Requests (current value: {{ $value }})'
       expr: |
-        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate30m{}) > (6.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate30m{}) > (6.00 * (1-0.99000))
         and
-        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h{}) > (6.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h{}) > (6.00 * (1-0.99000))
       for: 15m
       labels:
         name: FailedProduceRequestsPerSec
@@ -35,9 +35,9 @@ spec:
       annotations:
         message: 'High error budget burn for Failed Produce Requests (current value: {{ $value }})'
       expr: |
-        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate2h{}) > (3.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate2h{}) > (3.00 * (1-0.99000))
         and
-        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1d{}) > (3.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate1d{}) > (3.00 * (1-0.99000))
       for: 1h
       labels:
         name: FailedProduceRequestsPerSec
@@ -46,9 +46,9 @@ spec:
       annotations:
         message: 'High error budget burn for Failed Produce Requests (current value: {{ $value }})'
       expr: |
-        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h{}) > (1.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate6h{}) > (1.00 * (1-0.99000))
         and
-        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate3d{}) > (1.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_produce_requests_total:burnrate3d{}) > (1.00 * (1-0.99000))
       for: 3h
       labels:
         name: FailedProduceRequestsPerSec
@@ -106,9 +106,9 @@ spec:
       annotations:
         message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
       expr: |
-        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate5m{}) > (14.40 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate5m{}) > (14.40 * (1-0.99000))
         and
-        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1h{}) > (14.40 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1h{}) > (14.40 * (1-0.99000))
       for: 2m
       labels:
         name: FailedFetchRequestsPerSec
@@ -117,9 +117,9 @@ spec:
       annotations:
         message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
       expr: |
-        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate30m{}) > (6.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate30m{}) > (6.00 * (1-0.99000))
         and
-        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h{}) > (6.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h{}) > (6.00 * (1-0.99000))
       for: 15m
       labels:
         name: FailedFetchRequestsPerSec
@@ -128,9 +128,9 @@ spec:
       annotations:
         message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
       expr: |
-        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate2h{}) > (3.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate2h{}) > (3.00 * (1-0.99000))
         and
-        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1d{}) > (3.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate1d{}) > (3.00 * (1-0.99000))
       for: 1h
       labels:
         name: FailedFetchRequestsPerSec
@@ -139,9 +139,9 @@ spec:
       annotations:
         message: 'High error budget burn for Failed Fetch Requests (current value: {{ $value }})'
       expr: |
-        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h{}) > (1.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate6h{}) > (1.00 * (1-0.99000))
         and
-        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate3d{}) > (1.00 * (1-0.90000))
+        sum(kafka_server_brokertopicmetrics_failed_fetch_requests_total:burnrate3d{}) > (1.00 * (1-0.99000))
       for: 3h
       labels:
         name: FailedFetchRequestsPerSec
@@ -199,9 +199,9 @@ spec:
       annotations:
         message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
       expr: |
-        sum(haproxy_server_connection_errors_total:burnrate5m) > (14.40 * (1-0.90000))
+        sum(haproxy_server_connection_errors_total:burnrate5m) > (14.40 * (1-0.99000))
         and
-        sum(haproxy_server_connection_errors_total:burnrate1h) > (14.40 * (1-0.90000))
+        sum(haproxy_server_connection_errors_total:burnrate1h) > (14.40 * (1-0.99000))
       for: 2m
       labels:
         name: FailedConnectionsPerSec
@@ -210,9 +210,9 @@ spec:
       annotations:
         message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
       expr: |
-        sum(haproxy_server_connection_errors_total:burnrate30m) > (6.00 * (1-0.90000))
+        sum(haproxy_server_connection_errors_total:burnrate30m) > (6.00 * (1-0.99000))
         and
-        sum(haproxy_server_connection_errors_total:burnrate6h) > (6.00 * (1-0.90000))
+        sum(haproxy_server_connection_errors_total:burnrate6h) > (6.00 * (1-0.99000))
       for: 15m
       labels:
         name: FailedConnectionsPerSec
@@ -221,9 +221,9 @@ spec:
       annotations:
         message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
       expr: |
-        sum(haproxy_server_connection_errors_total:burnrate2h) > (3.00 * (1-0.90000))
+        sum(haproxy_server_connection_errors_total:burnrate2h) > (3.00 * (1-0.99000))
         and
-        sum(haproxy_server_connection_errors_total:burnrate1d) > (3.00 * (1-0.90000))
+        sum(haproxy_server_connection_errors_total:burnrate1d) > (3.00 * (1-0.99000))
       for: 1h
       labels:
         name: FailedConnectionsPerSec
@@ -232,9 +232,9 @@ spec:
       annotations:
         message: 'High error budget burn for haproxy connection errors (current value: {{ $value }})'
       expr: |
-        sum(haproxy_server_connection_errors_total:burnrate6h) > (1.00 * (1-0.90000))
+        sum(haproxy_server_connection_errors_total:burnrate6h) > (1.00 * (1-0.99000))
         and
-        sum(haproxy_server_connection_errors_total:burnrate3d) > (1.00 * (1-0.90000))
+        sum(haproxy_server_connection_errors_total:burnrate3d) > (1.00 * (1-0.99000))
       for: 3h
       labels:
         name: FailedConnectionsPerSec


### PR DESCRIPTION
…rt tests"

<!--  Issue these changes relate to -->
## Added alert test rules and error budget panels in dashbord for producer request,fetch requests,connection errors

<!-- Why these changes are required -->
## 3 panels
- producer errors (kafka producer requests)
- fetch errors(kafka consumer requests)
- connection errors (measured at haproxy)

<!-- How this PR implements these changes  -->
## promethues-rules.yaml,strimzi-kafka-sli dashborads

![dashborad](https://user-images.githubusercontent.com/16187022/100218035-2e84dd00-2f3a-11eb-8fad-44fa1eacb18b.png)
