### PR TITLE
Kafka Cluster - compute metrics dashboards (USE Method)

### DIFF
--- a/install/resources/monitoring-cluster/prometheus/federation.yaml
+++ b/install/resources/monitoring-cluster/prometheus/federation.yaml
@@ -26,6 +26,8 @@
       - '{__name__="container_last_seen"}'
       - '{__name__=~":node_memory_.*"}'
       - '{__name__=~"csv_.*"}'
+      - '{__name__=~"node_.*"}'
+      - '{__name__=~"container_network.*"}'
   scheme: https
   tls_config:
     insecure_skip_verify: true

--- a/install/resources/monitoring-cluster/prometheus/federation.yaml
+++ b/install/resources/monitoring-cluster/prometheus/federation.yaml
@@ -16,6 +16,8 @@
       - 'kubelet_volume_stats_used_bytes{endpoint="https-metrics",namespace!~"openshift-.*$",namespace!~"kube-.*$",namespace!="default"}'
       - 'kubelet_volume_stats_available_bytes{endpoint="https-metrics",namespace!~"openshift-.*$",namespace!~"kube-.*$",namespace!="default"}'
       - 'kubelet_volume_stats_capacity_bytes{endpoint="https-metrics",namespace!~"openshift-.*$",namespace!~"kube-.*$",namespace!="default"}'
+      - 'kubelet_volume_stats_inodes{endpoint="https-metrics",namespace!~"openshift-.*$",namespace!~"kube-.*$",namespace!="default"}'
+      - 'kubelet_volume_stats_inodes_used{endpoint="https-metrics",namespace!~"openshift-.*$",namespace!~"kube-.*$",namespace!="default"}'
       - '{service="kube-state-metrics"}'
       - '{service="node-exporter"}'
       - '{__name__=~"node_namespace_pod_container:.*"}'

--- a/install/resources/monitoring-cluster/prometheus/prometheus-observatorium.yaml
+++ b/install/resources/monitoring-cluster/prometheus/prometheus-observatorium.yaml
@@ -21,7 +21,7 @@ spec:
         insecureSkipVerify: true
       writeRelabelConfigs:
         - action: keep
-          regex: (kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total)
+          regex: (kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total|node.*$|kube.*$|container.*$)
           sourceLabels:
             - __name__
   ruleSelector: { }

--- a/install/resources/monitoring-cluster/prometheus/prometheus.yaml
+++ b/install/resources/monitoring-cluster/prometheus/prometheus.yaml
@@ -78,7 +78,7 @@ spec:
         insecureSkipVerify: true
       writeRelabelConfigs:
         - action: keep
-          regex: (kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total)
+          regex: (kafka_controller.*$|console_url$|csv_succeeded$|csv_abnormal$|cluster_version$|ALERTS$|strimzi_.*$|subscription_sync_total|node.*$|kube.*$|container.*$)
           sourceLabels:
             - __name__
   ruleSelector: { }

--- a/install/resources/monitoring-global/Makefile
+++ b/install/resources/monitoring-global/Makefile
@@ -42,6 +42,9 @@ create/dashboards:
 	@echo "creating global kafka dashboards"
 	@cat ./dashboards/fleet.yaml | sed -e 's/<namespace>/$(GLOBAL_MONITORING_NAMESPACE)/g' | cat | oc apply -f -
 	@cat ./dashboards/logs.yaml | sed -e 's/<namespace>/$(GLOBAL_MONITORING_NAMESPACE)/g' | cat | oc apply -f -
+	@cat ./dashboards/namespace.yaml | sed -e 's/<namespace>/$(GLOBAL_MONITORING_NAMESPACE)/g' | cat | oc apply -f -
+	@cat ./dashboards/pod.yaml | sed -e 's/<namespace>/$(GLOBAL_MONITORING_NAMESPACE)/g' | cat | oc apply -f -
+	@cat ./dashboards/pv.yaml | sed -e 's/<namespace>/$(GLOBAL_MONITORING_NAMESPACE)/g' | cat | oc apply -f -
 
 all: create/namespace create/thanos/receiver create/thanos/querier create/grafana create/dashboards create/loki
 	@echo "Done installing fleet wide monitoring stack"

--- a/install/resources/monitoring-global/dashboards/namespace.yaml
+++ b/install/resources/monitoring-global/dashboards/namespace.yaml
@@ -1,0 +1,2760 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: strimzi
+  name: kafka-namespace
+  namespace: <namespace>
+spec:
+  plugins:
+    - name: "grafana-piechart-panel"
+      version: "1.5.0"
+  name: kafkans.json
+  json: |
+    {
+        "annotations": {
+          "list": [
+            {
+              "builtIn": 1,
+              "datasource": "-- Grafana --",
+              "enable": true,
+              "hide": true,
+              "iconColor": "rgba(0, 211, 255, 1)",
+              "name": "Annotations & Alerts",
+              "type": "dashboard"
+            }
+          ]
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": 7,
+        "iteration": 1606240066180,
+        "links": [],
+        "panels": [
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 0
+            },
+            "id": 16,
+            "panels": [],
+            "repeat": null,
+            "title": "Headlines",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#299c46",
+              "rgba(237, 129, 40, 0.89)",
+              "#d44a3a"
+            ],
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 1,
+            "format": "percentunit",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 3,
+              "w": 6,
+              "x": 0,
+              "y": 1
+            },
+            "id": 1,
+            "interval": null,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "null as zero",
+            "nullText": null,
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false,
+              "ymax": null,
+              "ymin": null
+            },
+            "stack": false,
+            "steppedLine": false,
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\"})",
+                "format": "time_series",
+                "instant": true,
+                "intervalFactor": 2,
+                "refId": "A"
+              }
+            ],
+            "thresholds": "70,80",
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU Utilisation (from requests)",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#299c46",
+              "rgba(237, 129, 40, 0.89)",
+              "#d44a3a"
+            ],
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 1,
+            "format": "percentunit",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 3,
+              "w": 6,
+              "x": 6,
+              "y": 1
+            },
+            "id": 2,
+            "interval": null,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "null as zero",
+            "nullText": null,
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false,
+              "ymax": null,
+              "ymin": null
+            },
+            "stack": false,
+            "steppedLine": false,
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) / sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\"})",
+                "format": "time_series",
+                "instant": true,
+                "intervalFactor": 2,
+                "refId": "A"
+              }
+            ],
+            "thresholds": "70,80",
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU Utilisation (from limits)",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#299c46",
+              "rgba(237, 129, 40, 0.89)",
+              "#d44a3a"
+            ],
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 1,
+            "format": "percentunit",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 3,
+              "w": 6,
+              "x": 12,
+              "y": 1
+            },
+            "id": 3,
+            "interval": null,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "null as zero",
+            "nullText": null,
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false,
+              "ymax": null,
+              "ymin": null
+            },
+            "stack": false,
+            "steppedLine": false,
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\"})",
+                "format": "time_series",
+                "instant": true,
+                "intervalFactor": 2,
+                "refId": "A"
+              }
+            ],
+            "thresholds": "70,80",
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Memory Utilization (from requests)",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "cacheTimeout": null,
+            "colorBackground": false,
+            "colorValue": false,
+            "colors": [
+              "#299c46",
+              "rgba(237, 129, 40, 0.89)",
+              "#d44a3a"
+            ],
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 1,
+            "format": "percentunit",
+            "gauge": {
+              "maxValue": 100,
+              "minValue": 0,
+              "show": false,
+              "thresholdLabels": false,
+              "thresholdMarkers": true
+            },
+            "gridPos": {
+              "h": 3,
+              "w": 6,
+              "x": 18,
+              "y": 1
+            },
+            "id": 4,
+            "interval": null,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "mappingType": 1,
+            "mappingTypes": [
+              {
+                "name": "value to text",
+                "value": 1
+              },
+              {
+                "name": "range to text",
+                "value": 2
+              }
+            ],
+            "maxDataPoints": 100,
+            "nullPointMode": "null as zero",
+            "nullText": null,
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "postfix": "",
+            "postfixFontSize": "50%",
+            "prefix": "",
+            "prefixFontSize": "50%",
+            "rangeMaps": [
+              {
+                "from": "null",
+                "text": "N/A",
+                "to": "null"
+              }
+            ],
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "sparkline": {
+              "fillColor": "rgba(31, 118, 189, 0.18)",
+              "full": false,
+              "lineColor": "rgb(31, 120, 193)",
+              "show": false,
+              "ymax": null,
+              "ymin": null
+            },
+            "stack": false,
+            "steppedLine": false,
+            "tableColumn": "",
+            "targets": [
+              {
+                "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\"})",
+                "format": "time_series",
+                "instant": true,
+                "intervalFactor": 2,
+                "refId": "A"
+              }
+            ],
+            "thresholds": "70,80",
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Memory Utilisation (from limits)",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "singlestat",
+            "valueFontSize": "80%",
+            "valueMaps": [
+              {
+                "op": "=",
+                "text": "N/A",
+                "value": "null"
+              }
+            ],
+            "valueName": "avg",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ]
+          },
+          {
+            "collapsed": true,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 4
+            },
+            "id": 17,
+            "panels": [
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {}
+                  },
+                  "overrides": []
+                },
+                "fill": 10,
+                "fillGradient": 0,
+                "gridPos": {
+                  "h": 7,
+                  "w": 24,
+                  "x": 0,
+                  "y": 5
+                },
+                "hiddenSeries": false,
+                "id": 5,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pluginVersion": "7.1.1",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [
+                  {
+                    "alias": "quota - requests",
+                    "color": "#F2495C",
+                    "dashes": true,
+                    "fill": 0,
+                    "hideTooltip": true,
+                    "legend": false,
+                    "linewidth": 2,
+                    "stack": false
+                  },
+                  {
+                    "alias": "quota - limits",
+                    "color": "#FF9830",
+                    "dashes": true,
+                    "fill": 0,
+                    "hideTooltip": true,
+                    "legend": false,
+                    "linewidth": 2,
+                    "stack": false
+                  }
+                ],
+                "spaceLength": 10,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{pod}}",
+                    "legendLink": null,
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.cpu\"})",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "quota - requests",
+                    "legendLink": null,
+                    "refId": "B",
+                    "step": 10
+                  },
+                  {
+                    "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.cpu\"})",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "quota - limits",
+                    "legendLink": null,
+                    "refId": "C",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeRegions": [],
+                "timeShift": null,
+                "title": "CPU Usage",
+                "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ],
+                "yaxis": {
+                  "align": false,
+                  "alignLevel": null
+                }
+              }
+            ],
+            "repeat": null,
+            "title": "CPU Usage",
+            "type": "row"
+          },
+          {
+            "collapsed": true,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 5
+            },
+            "id": 18,
+            "panels": [
+              {
+                "aliasColors": {},
+                "bars": false,
+                "columns": [],
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {}
+                  },
+                  "overrides": []
+                },
+                "fill": 1,
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 7,
+                  "w": 24,
+                  "x": 0,
+                  "y": 6
+                },
+                "id": 6,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null as zero",
+                "pageSize": null,
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "showHeader": true,
+                "sort": {
+                  "col": 0,
+                  "desc": true
+                },
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "styles": [
+                  {
+                    "alias": "Time",
+                    "align": "auto",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "pattern": "Time",
+                    "type": "hidden"
+                  },
+                  {
+                    "alias": "CPU Usage",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #A",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "CPU Requests",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #B",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "CPU Requests %",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #C",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "percentunit"
+                  },
+                  {
+                    "alias": "CPU Limits",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #D",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "CPU Limits %",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #E",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "percentunit"
+                  },
+                  {
+                    "alias": "Pod",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "./d/c527b1a05cb2434b9e7e1db4b411b3d4/strimzi-kafka-fleet-panel-compute-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                    "pattern": "pod",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "B",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "C",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "D",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod) / sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "E",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "CPU Quota",
+                "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "transform": "table",
+                "type": "table-old",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ]
+              }
+            ],
+            "repeat": null,
+            "title": "CPU Quota",
+            "type": "row"
+          },
+          {
+            "collapsed": true,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 6
+            },
+            "id": 19,
+            "panels": [
+              {
+                "aliasColors": {},
+                "bars": false,
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {}
+                  },
+                  "overrides": []
+                },
+                "fill": 10,
+                "fillGradient": 0,
+                "gridPos": {
+                  "h": 7,
+                  "w": 24,
+                  "x": 0,
+                  "y": 4
+                },
+                "hiddenSeries": false,
+                "id": 7,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 0,
+                "links": [],
+                "nullPointMode": "null as zero",
+                "percentage": false,
+                "pluginVersion": "7.1.1",
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [
+                  {
+                    "alias": "quota - requests",
+                    "color": "#F2495C",
+                    "dashes": true,
+                    "fill": 0,
+                    "hideTooltip": true,
+                    "legend": false,
+                    "linewidth": 2,
+                    "stack": false
+                  },
+                  {
+                    "alias": "quota - limits",
+                    "color": "#FF9830",
+                    "dashes": true,
+                    "fill": 0,
+                    "hideTooltip": true,
+                    "legend": false,
+                    "linewidth": 2,
+                    "stack": false
+                  }
+                ],
+                "spaceLength": 10,
+                "stack": true,
+                "steppedLine": false,
+                "targets": [
+                  {
+                    "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", container!=\"\"}) by (pod)",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "{{pod}}",
+                    "legendLink": null,
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"requests.memory\"})",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "quota - requests",
+                    "legendLink": null,
+                    "refId": "B",
+                    "step": 10
+                  },
+                  {
+                    "expr": "scalar(kube_resourcequota{cluster=\"$cluster\", namespace=\"$namespace\", type=\"hard\",resource=\"limits.memory\"})",
+                    "format": "time_series",
+                    "intervalFactor": 2,
+                    "legendFormat": "quota - limits",
+                    "legendLink": null,
+                    "refId": "C",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeRegions": [],
+                "timeShift": null,
+                "title": "Memory Usage (w/o cache)",
+                "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "type": "graph",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "bytes",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ],
+                "yaxis": {
+                  "align": false,
+                  "alignLevel": null
+                }
+              }
+            ],
+            "repeat": null,
+            "title": "Memory Usage",
+            "type": "row"
+          },
+          {
+            "collapsed": true,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 7
+            },
+            "id": 20,
+            "panels": [
+              {
+                "aliasColors": {},
+                "bars": false,
+                "columns": [],
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {}
+                  },
+                  "overrides": []
+                },
+                "fill": 1,
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 7,
+                  "w": 24,
+                  "x": 0,
+                  "y": 5
+                },
+                "id": 8,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null as zero",
+                "pageSize": null,
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "showHeader": true,
+                "sort": {
+                  "col": 0,
+                  "desc": true
+                },
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "styles": [
+                  {
+                    "alias": "Time",
+                    "align": "auto",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "pattern": "Time",
+                    "type": "hidden"
+                  },
+                  {
+                    "alias": "Memory Usage",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #A",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "bytes"
+                  },
+                  {
+                    "alias": "Memory Requests",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #B",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "bytes"
+                  },
+                  {
+                    "alias": "Memory Requests %",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #C",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "percentunit"
+                  },
+                  {
+                    "alias": "Memory Limits",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #D",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "bytes"
+                  },
+                  {
+                    "alias": "Memory Limits %",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #E",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "percentunit"
+                  },
+                  {
+                    "alias": "Memory Usage (RSS)",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #F",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "bytes"
+                  },
+                  {
+                    "alias": "Memory Usage (Cache)",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #G",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "bytes"
+                  },
+                  {
+                    "alias": "Memory Usage (Swap)",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #H",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "bytes"
+                  },
+                  {
+                    "alias": "Pod",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "./d/c527b1a05cb2434b9e7e1db4b411b3d4/strimzi-kafka-fleet-panel-compute-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                    "pattern": "pod",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(kube_pod_container_resource_requests_memory_bytes{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "B",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "C",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(kube_pod_container_resource_limits_memory_bytes{cluster=\"$cluster\", namespace=\"$namespace\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "D",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "E",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(container_memory_rss{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "F",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(container_memory_cache{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "G",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(container_memory_swap{cluster=\"$cluster\", namespace=\"$namespace\",container!=\"\"}) by (pod)",
+                    "format": "table",
+                    "instant": true,
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "H",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Memory Quota",
+                "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "transform": "table",
+                "type": "table-old",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ]
+              }
+            ],
+            "repeat": null,
+            "title": "Memory Quota",
+            "type": "row"
+          },
+          {
+            "collapsed": true,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 8
+            },
+            "id": 29,
+            "panels": [
+              {
+                "datasource": "Thanos",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {
+                      "align": null
+                    },
+                    "links": [
+                      {
+                        "title": "Drill down",
+                        "url": "./d/3aa63e28e57e5e48febcd3f5aead600e2c5afa9e/strimzi-kafka-fleet-panel-compute-resources-pv?var-datasource=$datasource&var-volume=${__value.raw}&var-namespace=$namespace"
+                      }
+                    ],
+                    "mappings": [],
+                    "thresholds": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "red",
+                          "value": 80
+                        }
+                      ]
+                    },
+                    "unit": "decbytes"
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "Percentage Available"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 277
+                        },
+                        {
+                          "id": "unit",
+                          "value": "percent"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                "gridPos": {
+                  "h": 7,
+                  "w": 24,
+                  "x": 0,
+                  "y": 6
+                },
+                "id": 30,
+                "links": [],
+                "options": {
+                  "frameIndex": 1,
+                  "showHeader": true,
+                  "sortBy": [
+                    {
+                      "desc": true,
+                      "displayName": "Total Size"
+                    }
+                  ]
+                },
+                "pluginVersion": "7.1.1",
+                "targets": [
+                  {
+                    "expr": "sum(kubelet_volume_stats_capacity_bytes{job=\"kubelet\", namespace=\"$namespace\"}) by (persistentvolumeclaim)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(kubelet_volume_stats_available_bytes{job=\"kubelet\", namespace=\"$namespace\"}) by (persistentvolumeclaim)",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "B"
+                  },
+                  {
+                    "expr": "(kubelet_volume_stats_available_bytes{ job=\"kubelet\", namespace=\"$namespace\"} / kubelet_volume_stats_capacity_bytes{ job=\"kubelet\", namespace=\"$namespace\"} * 100) ",
+                    "format": "table",
+                    "instant": true,
+                    "interval": "",
+                    "intervalFactor": 2,
+                    "legendFormat": "",
+                    "refId": "C"
+                  }
+                ],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "PV usage",
+                "transformations": [
+                  {
+                    "id": "seriesToColumns",
+                    "options": {
+                      "byField": "persistentvolumeclaim"
+                    }
+                  },
+                  {
+                    "id": "organize",
+                    "options": {
+                      "excludeByName": {
+                        "Time": true,
+                        "cluster_id": true,
+                        "endpoint": true,
+                        "instance": true,
+                        "job": true,
+                        "metrics_path": true,
+                        "namespace": true,
+                        "node": true,
+                        "prometheus": true,
+                        "prometheus_replica": true,
+                        "service": true,
+                        "tenant_id": true
+                      },
+                      "indexByName": {},
+                      "renameByName": {
+                        "Value #A": "Total Size",
+                        "Value #B": "Available Space",
+                        "Value #C": "Percentage Available"
+                      }
+                    }
+                  }
+                ],
+                "type": "table"
+              }
+            ],
+            "title": "PV Usage",
+            "type": "row"
+          },
+          {
+            "collapsed": true,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 9
+            },
+            "id": 21,
+            "panels": [
+              {
+                "aliasColors": {},
+                "bars": false,
+                "columns": [],
+                "dashLength": 10,
+                "dashes": false,
+                "datasource": "$datasource",
+                "fieldConfig": {
+                  "defaults": {
+                    "custom": {}
+                  },
+                  "overrides": []
+                },
+                "fill": 1,
+                "fontSize": "100%",
+                "gridPos": {
+                  "h": 7,
+                  "w": 24,
+                  "x": 0,
+                  "y": 7
+                },
+                "id": 9,
+                "legend": {
+                  "avg": false,
+                  "current": false,
+                  "max": false,
+                  "min": false,
+                  "show": true,
+                  "total": false,
+                  "values": false
+                },
+                "lines": true,
+                "linewidth": 1,
+                "links": [],
+                "nullPointMode": "null as zero",
+                "pageSize": null,
+                "percentage": false,
+                "pointradius": 5,
+                "points": false,
+                "renderer": "flot",
+                "seriesOverrides": [],
+                "showHeader": true,
+                "sort": {
+                  "col": 0,
+                  "desc": true
+                },
+                "spaceLength": 10,
+                "stack": false,
+                "steppedLine": false,
+                "styles": [
+                  {
+                    "alias": "Time",
+                    "align": "auto",
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "pattern": "Time",
+                    "type": "hidden"
+                  },
+                  {
+                    "alias": "Current Receive Bandwidth",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #A",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "Bps"
+                  },
+                  {
+                    "alias": "Current Transmit Bandwidth",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #B",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "Bps"
+                  },
+                  {
+                    "alias": "Rate of Received Packets",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #C",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "pps"
+                  },
+                  {
+                    "alias": "Rate of Transmitted Packets",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #D",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "pps"
+                  },
+                  {
+                    "alias": "Rate of Received Packets Dropped",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #E",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "pps"
+                  },
+                  {
+                    "alias": "Rate of Transmitted Packets Dropped",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": false,
+                    "linkTooltip": "Drill down",
+                    "linkUrl": "",
+                    "pattern": "Value #F",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "pps"
+                  },
+                  {
+                    "alias": "Pod",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "link": true,
+                    "linkTooltip": "Drill down to pods",
+                    "linkUrl": "./d/c527b1a05cb2434b9e7e1db4b411b3d4/strimzi-kafka-fleet-panel-compute-resources-pod?var-datasource=$datasource&var-cluster=$cluster&var-namespace=$namespace&var-pod=$__cell",
+                    "pattern": "pod",
+                    "thresholds": [],
+                    "type": "number",
+                    "unit": "short"
+                  },
+                  {
+                    "alias": "",
+                    "align": "auto",
+                    "colorMode": null,
+                    "colors": [],
+                    "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                    "decimals": 2,
+                    "pattern": "/.*/",
+                    "thresholds": [],
+                    "type": "string",
+                    "unit": "short"
+                  }
+                ],
+                "targets": [
+                  {
+                    "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                    "format": "table",
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 10,
+                    "legendFormat": "",
+                    "refId": "A",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                    "format": "table",
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 10,
+                    "legendFormat": "",
+                    "refId": "B",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                    "format": "table",
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 10,
+                    "legendFormat": "",
+                    "refId": "C",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(irate(container_network_transmit_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                    "format": "table",
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 10,
+                    "legendFormat": "",
+                    "refId": "D",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                    "format": "table",
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 10,
+                    "legendFormat": "",
+                    "refId": "E",
+                    "step": 10
+                  },
+                  {
+                    "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                    "format": "table",
+                    "instant": false,
+                    "interval": "",
+                    "intervalFactor": 10,
+                    "legendFormat": "",
+                    "refId": "F",
+                    "step": 10
+                  }
+                ],
+                "thresholds": [],
+                "timeFrom": null,
+                "timeShift": null,
+                "title": "Current Network Usage",
+                "tooltip": {
+                  "shared": false,
+                  "sort": 0,
+                  "value_type": "individual"
+                },
+                "transform": "table",
+                "transformations": [
+                  {
+                    "id": "seriesToColumns",
+                    "options": {
+                      "byField": "pod"
+                    }
+                  }
+                ],
+                "type": "table-old",
+                "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": []
+                },
+                "yaxes": [
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": 0,
+                    "show": true
+                  },
+                  {
+                    "format": "short",
+                    "label": null,
+                    "logBase": 1,
+                    "max": null,
+                    "min": null,
+                    "show": false
+                  }
+                ]
+              }
+            ],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 10
+            },
+            "id": 22,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 11
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(container_network_receive_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Receive Bandwidth",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 18
+            },
+            "id": 23,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 19
+            },
+            "hiddenSeries": false,
+            "id": 11,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(container_network_transmit_bytes_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Transmit Bandwidth",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 26
+            },
+            "id": 24,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 27
+            },
+            "hiddenSeries": false,
+            "id": 12,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Rate of Received Packets",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 34
+            },
+            "id": 25,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 35
+            },
+            "hiddenSeries": false,
+            "id": 13,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(container_network_receive_packets_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Rate of Transmitted Packets",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 42
+            },
+            "id": 26,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 43
+            },
+            "hiddenSeries": false,
+            "id": 14,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(container_network_receive_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Rate of Received Packets Dropped",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          },
+          {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+              "h": 1,
+              "w": 24,
+              "x": 0,
+              "y": 50
+            },
+            "id": 27,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "custom": {}
+              },
+              "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+              "h": 7,
+              "w": 24,
+              "x": 0,
+              "y": 51
+            },
+            "hiddenSeries": false,
+            "id": 15,
+            "legend": {
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "show": true,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(irate(container_network_transmit_packets_dropped_total{cluster=\"$cluster\", namespace=~\"$namespace\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Rate of Transmitted Packets Dropped",
+            "tooltip": {
+              "shared": false,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+              }
+            ],
+            "yaxis": {
+              "align": false,
+              "alignLevel": null
+            }
+          }
+        ],
+        "refresh": "10s",
+        "schemaVersion": 26,
+        "style": "dark",
+        "tags": [
+          "kubernetes-mixin"
+        ],
+        "templating": {
+          "list": [
+            {
+              "current": {
+                "selected": false,
+                "text": "default",
+                "value": "default"
+              },
+              "hide": 0,
+              "includeAll": false,
+              "label": null,
+              "multi": false,
+              "name": "datasource",
+              "options": [],
+              "query": "prometheus",
+              "queryValue": "",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "type": "datasource"
+            },
+            {
+              "allValue": null,
+              "current": {
+                "isNone": true,
+                "selected": false,
+                "text": "None",
+                "value": ""
+              },
+              "datasource": "$datasource",
+              "definition": "",
+              "hide": 2,
+              "includeAll": false,
+              "label": null,
+              "multi": false,
+              "name": "cluster",
+              "options": [],
+              "query": "label_values(kube_pod_info, cluster)",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 1,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            },
+            {
+              "allValue": null,
+              "current": {
+                "selected": false,
+                "text": "kafka-cluster",
+                "value": "kafka-cluster"
+              },
+              "datasource": "$datasource",
+              "definition": "",
+              "hide": 0,
+              "includeAll": false,
+              "label": null,
+              "multi": false,
+              "name": "namespace",
+              "options": [],
+              "query": "label_values(kube_pod_info{namespace !~\"openshift.*\", namespace !~\".*monitor.*\"}, namespace)",
+              "refresh": 1,
+              "regex": "",
+              "skipUrlSync": false,
+              "sort": 1,
+              "tagValuesQuery": "",
+              "tags": [],
+              "tagsQuery": "",
+              "type": "query",
+              "useTags": false
+            }
+          ]
+        },
+        "time": {
+          "from": "now-1h",
+          "to": "now"
+        },
+        "timepicker": {
+          "refresh_intervals": [
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+          ],
+          "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+          ]
+        },
+        "timezone": "",
+        "title": "Strimzi / Kafka Fleet Panel / Compute Resources / Namespace",
+        "uid": "c37212696a6c9b90acae3af21966521e06169e1c",
+        "version": 2
+    }
+    

--- a/install/resources/monitoring-global/dashboards/pod.yaml
+++ b/install/resources/monitoring-global/dashboards/pod.yaml
@@ -1,0 +1,1856 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: strimzi
+  name: kafka-pod
+  namespace: <namespace>
+spec:
+  plugins:
+    - name: "grafana-piechart-panel"
+      version: "1.5.0"
+  name: kafkapod.json
+  json: |
+    {
+        "annotations": {
+            "list": [
+            {
+                "builtIn": 1,
+                "datasource": "-- Grafana --",
+                "enable": true,
+                "hide": true,
+                "iconColor": "rgba(0, 211, 255, 1)",
+                "name": "Annotations & Alerts",
+                "type": "dashboard"
+            }
+            ]
+        },
+        "editable": true,
+        "gnetId": null,
+        "graphTooltip": 0,
+        "id": 4,
+        "iteration": 1606256932072,
+        "links": [],
+        "panels": [
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 0
+            },
+            "id": 12,
+            "panels": [],
+            "repeat": null,
+            "title": "CPU Usage",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 1
+            },
+            "hiddenSeries": false,
+            "id": 1,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                "alias": "requests",
+                "color": "#F2495C",
+                "fill": 0,
+                "hideTooltip": true,
+                "legend": true,
+                "linewidth": 2,
+                "stack": false
+                },
+                {
+                "alias": "limits",
+                "color": "#FF9830",
+                "fill": 0,
+                "hideTooltip": true,
+                "legend": true,
+                "linewidth": 2,
+                "stack": false
+                }
+            ],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", cluster=\"$cluster\"}) by (container)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{container}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+                },
+                {
+                "expr": "sum(\n    kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"})\n",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "requests",
+                "legendLink": null,
+                "refId": "B",
+                "step": 10
+                },
+                {
+                "expr": "sum(\n    kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"})\n",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "limits",
+                "legendLink": null,
+                "refId": "C",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CPU Usage",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 8
+            },
+            "id": 13,
+            "panels": [],
+            "repeat": null,
+            "title": "CPU Throttling",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 9
+            },
+            "hiddenSeries": false,
+            "id": 2,
+            "legend": {
+                "avg": false,
+                "current": true,
+                "max": true,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(increase(container_cpu_cfs_throttled_periods_total{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", cluster=\"$cluster\"}[5m])) by (container) /sum(increase(container_cpu_cfs_periods_total{namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", cluster=\"$cluster\"}[5m])) by (container)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{container}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "thresholds": [
+                {
+                "colorMode": "critical",
+                "fill": true,
+                "line": true,
+                "op": "gt",
+                "value": 0.25,
+                "yaxis": "left"
+                }
+            ],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "CPU Throttling",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": 1,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 16
+            },
+            "id": 14,
+            "panels": [],
+            "repeat": null,
+            "title": "CPU Quota",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "columns": [],
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 17
+            },
+            "id": 3,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "pageSize": null,
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "styles": [
+                {
+                "alias": "Time",
+                "align": "auto",
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "pattern": "Time",
+                "type": "hidden"
+                },
+                {
+                "alias": "CPU Usage",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #A",
+                "thresholds": [],
+                "type": "number",
+                "unit": "short"
+                },
+                {
+                "alias": "CPU Requests",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #B",
+                "thresholds": [],
+                "type": "number",
+                "unit": "short"
+                },
+                {
+                "alias": "CPU Requests %",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #C",
+                "thresholds": [],
+                "type": "number",
+                "unit": "percentunit"
+                },
+                {
+                "alias": "CPU Limits",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #D",
+                "thresholds": [],
+                "type": "number",
+                "unit": "short"
+                },
+                {
+                "alias": "CPU Limits %",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #E",
+                "thresholds": [],
+                "type": "number",
+                "unit": "percentunit"
+                },
+                {
+                "alias": "Container",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "container",
+                "thresholds": [],
+                "type": "number",
+                "unit": "short"
+                },
+                {
+                "alias": "",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "A",
+                "step": 10
+                },
+                {
+                "expr": "sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "B",
+                "step": 10
+                },
+                {
+                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_container_resource_requests_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "C",
+                "step": 10
+                },
+                {
+                "expr": "sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "D",
+                "step": 10
+                },
+                {
+                "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "E",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU Quota",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "transform": "table",
+            "type": "table-old",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ]
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 24
+            },
+            "id": 15,
+            "panels": [],
+            "repeat": null,
+            "title": "Memory Usage",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 25
+            },
+            "hiddenSeries": false,
+            "id": 4,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [
+                {
+                "alias": "requests",
+                "color": "#F2495C",
+                "dashes": true,
+                "fill": 0,
+                "hideTooltip": true,
+                "legend": false,
+                "linewidth": 2,
+                "stack": false
+                },
+                {
+                "alias": "limits",
+                "color": "#FF9830",
+                "dashes": true,
+                "fill": 0,
+                "hideTooltip": true,
+                "legend": false,
+                "linewidth": 2,
+                "stack": false
+                }
+            ],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", container!=\"\"}) by (container)",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{container}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+                },
+                {
+                "expr": "sum(\n    kube_pod_container_resource_requests_memory_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"})\n",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "requests",
+                "legendLink": null,
+                "refId": "B",
+                "step": 10
+                },
+                {
+                "expr": "sum(\n    kube_pod_container_resource_limits_memory_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"})\n",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "limits",
+                "legendLink": null,
+                "refId": "C",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Memory Usage",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 32
+            },
+            "id": 16,
+            "panels": [],
+            "repeat": null,
+            "title": "Memory Quota",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "columns": [],
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 1,
+            "fontSize": "100%",
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 33
+            },
+            "id": 5,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "pageSize": null,
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "showHeader": true,
+            "sort": {
+                "col": 0,
+                "desc": true
+            },
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "styles": [
+                {
+                "alias": "Time",
+                "align": "auto",
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "pattern": "Time",
+                "type": "hidden"
+                },
+                {
+                "alias": "Memory Usage",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #A",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+                },
+                {
+                "alias": "Memory Requests",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #B",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+                },
+                {
+                "alias": "Memory Requests %",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #C",
+                "thresholds": [],
+                "type": "number",
+                "unit": "percentunit"
+                },
+                {
+                "alias": "Memory Limits",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #D",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+                },
+                {
+                "alias": "Memory Limits %",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #E",
+                "thresholds": [],
+                "type": "number",
+                "unit": "percentunit"
+                },
+                {
+                "alias": "Memory Usage (RSS)",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #F",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+                },
+                {
+                "alias": "Memory Usage (Cache)",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #G",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+                },
+                {
+                "alias": "Memory Usage (Swap)",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "Value #H",
+                "thresholds": [],
+                "type": "number",
+                "unit": "bytes"
+                },
+                {
+                "alias": "Container",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "link": false,
+                "linkTooltip": "Drill down",
+                "linkUrl": "",
+                "pattern": "container",
+                "thresholds": [],
+                "type": "number",
+                "unit": "short"
+                },
+                {
+                "alias": "",
+                "align": "auto",
+                "colorMode": null,
+                "colors": [],
+                "dateFormat": "YYYY-MM-DD HH:mm:ss",
+                "decimals": 2,
+                "pattern": "/.*/",
+                "thresholds": [],
+                "type": "string",
+                "unit": "short"
+                }
+            ],
+            "targets": [
+                {
+                "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"POD\", container!=\"\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "A",
+                "step": 10
+                },
+                {
+                "expr": "sum(kube_pod_container_resource_requests_memory_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "B",
+                "step": 10
+                },
+                {
+                "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\"}) by (container) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "C",
+                "step": 10
+                },
+                {
+                "expr": "sum(kube_pod_container_resource_limits_memory_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "D",
+                "step": 10
+                },
+                {
+                "expr": "sum(container_memory_working_set_bytes{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container!=\"\"}) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=\"$namespace\", pod=\"$pod\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "E",
+                "step": 10
+                },
+                {
+                "expr": "sum(container_memory_rss{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "F",
+                "step": 10
+                },
+                {
+                "expr": "sum(container_memory_cache{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "G",
+                "step": 10
+                },
+                {
+                "expr": "sum(container_memory_swap{cluster=\"$cluster\", namespace=\"$namespace\", pod=\"$pod\", container != \"\", container != \"POD\"}) by (container)",
+                "format": "table",
+                "instant": true,
+                "intervalFactor": 2,
+                "legendFormat": "",
+                "refId": "H",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Memory Quota",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "transform": "table",
+            "type": "table-old",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ]
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 40
+            },
+            "id": 17,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 41
+            },
+            "hiddenSeries": false,
+            "id": 6,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(irate(container_network_receive_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Receive Bandwidth",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 48
+            },
+            "id": 18,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 49
+            },
+            "hiddenSeries": false,
+            "id": 7,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(irate(container_network_transmit_bytes_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Transmit Bandwidth",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 56
+            },
+            "id": 19,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 57
+            },
+            "hiddenSeries": false,
+            "id": 8,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(irate(container_network_receive_packets_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Rate of Received Packets",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 64
+            },
+            "id": 20,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 65
+            },
+            "hiddenSeries": false,
+            "id": 9,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(irate(container_network_transmit_packets_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Rate of Transmitted Packets",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 72
+            },
+            "id": 21,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 73
+            },
+            "hiddenSeries": false,
+            "id": 10,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(irate(container_network_receive_packets_dropped_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Rate of Received Packets Dropped",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+            },
+            {
+            "collapsed": false,
+            "datasource": null,
+            "gridPos": {
+                "h": 1,
+                "w": 24,
+                "x": 0,
+                "y": 80
+            },
+            "id": 22,
+            "panels": [],
+            "repeat": null,
+            "title": "Network",
+            "type": "row"
+            },
+            {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fieldConfig": {
+                "defaults": {
+                "custom": {}
+                },
+                "overrides": []
+            },
+            "fill": 10,
+            "fillGradient": 0,
+            "gridPos": {
+                "h": 7,
+                "w": 24,
+                "x": 0,
+                "y": 81
+            },
+            "hiddenSeries": false,
+            "id": 11,
+            "legend": {
+                "avg": false,
+                "current": false,
+                "max": false,
+                "min": false,
+                "show": true,
+                "total": false,
+                "values": false
+            },
+            "lines": true,
+            "linewidth": 0,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pluginVersion": "7.1.1",
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": true,
+            "steppedLine": false,
+            "targets": [
+                {
+                "expr": "sum(irate(container_network_transmit_packets_dropped_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__interval])) by (pod)",
+                "format": "time_series",
+                "interval": "",
+                "intervalFactor": 10,
+                "legendFormat": "{{pod}}",
+                "legendLink": null,
+                "refId": "A",
+                "step": 10
+                }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeRegions": [],
+            "timeShift": null,
+            "title": "Rate of Transmitted Packets Dropped",
+            "tooltip": {
+                "shared": false,
+                "sort": 0,
+                "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+                "buckets": null,
+                "mode": "time",
+                "name": null,
+                "show": true,
+                "values": []
+            },
+            "yaxes": [
+                {
+                "format": "Bps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+                },
+                {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": false
+                }
+            ],
+            "yaxis": {
+                "align": false,
+                "alignLevel": null
+            }
+            }
+        ],
+        "refresh": "10s",
+        "schemaVersion": 26,
+        "style": "dark",
+        "tags": [
+            "kubernetes-mixin"
+        ],
+        "templating": {
+            "list": [
+            {
+                "current": {
+                "selected": false,
+                "text": "default",
+                "value": "default"
+                },
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "datasource",
+                "options": [],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "type": "datasource"
+            },
+            {
+                "allValue": null,
+                "current": {
+                "isNone": true,
+                "selected": false,
+                "text": "None",
+                "value": ""
+                },
+                "datasource": "$datasource",
+                "definition": "",
+                "hide": 2,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "cluster",
+                "options": [],
+                "query": "label_values(kube_pod_info, cluster)",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                "selected": false,
+                "text": "kafka-cluster",
+                "value": "kafka-cluster"
+                },
+                "datasource": "$datasource",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "namespace",
+                "options": [],
+                "query": "label_values(kube_pod_info{namespace !~\"openshift.*\", namespace !~\".*monitor.*\"}, namespace)",
+                "refresh": 1,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": {
+                "selected": false,
+                "text": "my-cluster-kafka-0",
+                "value": "my-cluster-kafka-0"
+                },
+                "datasource": "$datasource",
+                "definition": "",
+                "hide": 0,
+                "includeAll": false,
+                "label": null,
+                "multi": false,
+                "name": "pod",
+                "options": [],
+                "query": "label_values(kube_pod_info{cluster=\"$cluster\", namespace=\"$namespace\"}, pod)",
+                "refresh": 2,
+                "regex": "",
+                "skipUrlSync": false,
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+            ]
+        },
+        "time": {
+            "from": "now-1h",
+            "to": "now"
+        },
+        "timepicker": {
+            "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+            ],
+            "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+            ]
+        },
+        "timezone": "",
+        "title": "Strimzi / Kafka Fleet Panel / Compute Resources / Pod",
+        "uid": "c527b1a05cb2434b9e7e1db4b411b3d4",
+        "version": 2
+    }    

--- a/install/resources/monitoring-global/dashboards/pv.yaml
+++ b/install/resources/monitoring-global/dashboards/pv.yaml
@@ -1,0 +1,507 @@
+apiVersion: integreatly.org/v1alpha1
+kind: GrafanaDashboard
+metadata:
+  labels:
+    app: strimzi
+  name: kafka-pv
+  namespace: <namespace>
+spec:
+  plugins:
+    - name: "grafana-piechart-panel"
+      version: "1.5.0"
+  name: kafkapv.json
+  json: |
+    {
+      "__inputs": [ ],
+      "__requires": [ ],
+      "annotations": {
+          "list": [ ]
+      },
+      "editable": false,
+      "gnetId": null,
+      "graphTooltip": 0,
+      "hideControls": false,
+      "id": null,
+      "links": [ ],
+      "refresh": "10s",
+      "rows": [
+          {
+            "collapse": false,
+            "collapsed": false,
+            "panels": [
+                {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 1,
+                  "fillGradient": 0,
+                  "gridPos": { },
+                  "id": 2,
+                  "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "repeat": null,
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 9,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                      {
+                        "expr": "(\n  sum without(instance, node) (kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n  -\n  sum without(instance, node) (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n)\n",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "Used Space",
+                        "refId": "A"
+                      },
+                      {
+                        "expr": "sum without(instance, node) (kubelet_volume_stats_available_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "Free Space",
+                        "refId": "B"
+                      }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Volume Space Usage",
+                  "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                  },
+                  "yaxes": [
+                      {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                      },
+                      {
+                        "format": "bytes",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                      }
+                  ]
+                },
+                {
+                  "cacheTimeout": null,
+                  "colorBackground": false,
+                  "colorValue": false,
+                  "colors": [
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(245, 54, 54, 0.9)"
+                  ],
+                  "datasource": "$datasource",
+                  "format": "percent",
+                  "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": true,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                  },
+                  "gridPos": { },
+                  "id": 3,
+                  "interval": null,
+                  "links": [ ],
+                  "mappingType": 1,
+                  "mappingTypes": [
+                      {
+                        "name": "value to text",
+                        "value": 1
+                      },
+                      {
+                        "name": "range to text",
+                        "value": 2
+                      }
+                  ],
+                  "maxDataPoints": 100,
+                  "nullPointMode": "connected",
+                  "nullText": null,
+                  "postfix": "",
+                  "postfixFontSize": "50%",
+                  "prefix": "",
+                  "prefixFontSize": "50%",
+                  "rangeMaps": [
+                      {
+                        "from": "null",
+                        "text": "N/A",
+                        "to": "null"
+                      }
+                  ],
+                  "span": 3,
+                  "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                  },
+                  "tableColumn": "",
+                  "targets": [
+                      {
+                        "expr": "(sum(kubelet_volume_stats_used_bytes{ job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"}) / sum(kubelet_volume_stats_capacity_bytes{ job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"}) * 100) ",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                  ],
+                  "thresholds": "80, 90",
+                  "title": "Volume Space Usage",
+                  "tooltip": {
+                      "shared": false
+                  },
+                  "type": "singlestat",
+                  "valueFontSize": "80%",
+                  "valueMaps": [
+                      {
+                        "op": "=",
+                        "text": "N/A",
+                        "value": "null"
+                      }
+                  ],
+                  "valueName": "current"
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": false,
+            "title": "Dashboard Row",
+            "titleSize": "h6",
+            "type": "row"
+          },
+          {
+            "collapse": false,
+            "collapsed": false,
+            "panels": [
+                {
+                  "aliasColors": { },
+                  "bars": false,
+                  "dashLength": 10,
+                  "dashes": false,
+                  "datasource": "$datasource",
+                  "fill": 1,
+                  "fillGradient": 0,
+                  "gridPos": { },
+                  "id": 4,
+                  "legend": {
+                      "alignAsTable": true,
+                      "avg": true,
+                      "current": true,
+                      "max": true,
+                      "min": true,
+                      "rightSide": false,
+                      "show": true,
+                      "sideWidth": null,
+                      "total": false,
+                      "values": true
+                  },
+                  "lines": true,
+                  "linewidth": 1,
+                  "links": [ ],
+                  "nullPointMode": "null",
+                  "percentage": false,
+                  "pointradius": 5,
+                  "points": false,
+                  "renderer": "flot",
+                  "repeat": null,
+                  "seriesOverrides": [ ],
+                  "spaceLength": 10,
+                  "span": 9,
+                  "stack": true,
+                  "steppedLine": false,
+                  "targets": [
+                      {
+                        "expr": "sum without(instance, node) (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": "Used inodes",
+                        "refId": "A"
+                      },
+                      {
+                        "expr": "(\n  sum without(instance, node) (kubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n  -\n  sum without(instance, node) (kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"})\n)\n",
+                        "format": "time_series",
+                        "intervalFactor": 1,
+                        "legendFormat": " Free inodes",
+                        "refId": "B"
+                      }
+                  ],
+                  "thresholds": [ ],
+                  "timeFrom": null,
+                  "timeShift": null,
+                  "title": "Volume inodes Usage",
+                  "tooltip": {
+                      "shared": false,
+                      "sort": 0,
+                      "value_type": "individual"
+                  },
+                  "type": "graph",
+                  "xaxis": {
+                      "buckets": null,
+                      "mode": "time",
+                      "name": null,
+                      "show": true,
+                      "values": [ ]
+                  },
+                  "yaxes": [
+                      {
+                        "format": "none",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                      },
+                      {
+                        "format": "none",
+                        "label": null,
+                        "logBase": 1,
+                        "max": null,
+                        "min": 0,
+                        "show": true
+                      }
+                  ]
+                },
+                {
+                  "cacheTimeout": null,
+                  "colorBackground": false,
+                  "colorValue": false,
+                  "colors": [
+                      "rgba(50, 172, 45, 0.97)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(245, 54, 54, 0.9)"
+                  ],
+                  "datasource": "$datasource",
+                  "format": "percent",
+                  "gauge": {
+                      "maxValue": 100,
+                      "minValue": 0,
+                      "show": true,
+                      "thresholdLabels": false,
+                      "thresholdMarkers": true
+                  },
+                  "gridPos": { },
+                  "id": 5,
+                  "interval": null,
+                  "links": [ ],
+                  "mappingType": 1,
+                  "mappingTypes": [
+                      {
+                        "name": "value to text",
+                        "value": 1
+                      },
+                      {
+                        "name": "range to text",
+                        "value": 2
+                      }
+                  ],
+                  "maxDataPoints": 100,
+                  "nullPointMode": "connected",
+                  "nullText": null,
+                  "postfix": "",
+                  "postfixFontSize": "50%",
+                  "prefix": "",
+                  "prefixFontSize": "50%",
+                  "rangeMaps": [
+                      {
+                        "from": "null",
+                        "text": "N/A",
+                        "to": "null"
+                      }
+                  ],
+                  "span": 3,
+                  "sparkline": {
+                      "fillColor": "rgba(31, 118, 189, 0.18)",
+                      "full": false,
+                      "lineColor": "rgb(31, 120, 193)",
+                      "show": false
+                  },
+                  "tableColumn": "",
+                  "targets": [
+                      {
+                        "expr": "kubelet_volume_stats_inodes_used{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"}\n/\nkubelet_volume_stats_inodes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\", persistentvolumeclaim=\"$volume\"}\n* 100\n",
+                        "format": "time_series",
+                        "intervalFactor": 2,
+                        "legendFormat": "",
+                        "refId": "A"
+                      }
+                  ],
+                  "thresholds": "80, 90",
+                  "title": "Volume inodes Usage",
+                  "tooltip": {
+                      "shared": false
+                  },
+                  "type": "singlestat",
+                  "valueFontSize": "80%",
+                  "valueMaps": [
+                      {
+                        "op": "=",
+                        "text": "N/A",
+                        "value": "null"
+                      }
+                  ],
+                  "valueName": "current"
+                }
+            ],
+            "repeat": null,
+            "repeatIteration": null,
+            "repeatRowId": null,
+            "showTitle": false,
+            "title": "Dashboard Row",
+            "titleSize": "h6",
+            "type": "row"
+          }
+      ],
+      "schemaVersion": 14,
+      "style": "dark",
+      "tags": [
+          "kubernetes-mixin"
+      ],
+      "templating": {
+          "list": [
+            {
+                "current": {
+                  "text": "default",
+                  "value": "default"
+                },
+                "hide": 0,
+                "label": null,
+                "name": "datasource",
+                "options": [ ],
+                "query": "prometheus",
+                "refresh": 1,
+                "regex": "",
+                "type": "datasource"
+            },
+            {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 2,
+                "includeAll": false,
+                "label": "cluster",
+                "multi": false,
+                "name": "cluster",
+                "options": [ ],
+                "query": "label_values(kubelet_volume_stats_capacity_bytes, cluster)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": "Namespace",
+                "multi": false,
+                "name": "namespace",
+                "options": [ ],
+                "query": "label_values(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\"}, namespace)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            },
+            {
+                "allValue": null,
+                "current": { },
+                "datasource": "$datasource",
+                "hide": 0,
+                "includeAll": false,
+                "label": "PersistentVolumeClaim",
+                "multi": false,
+                "name": "volume",
+                "options": [ ],
+                "query": "label_values(kubelet_volume_stats_capacity_bytes{cluster=\"$cluster\", job=\"kubelet\", namespace=\"$namespace\"}, persistentvolumeclaim)",
+                "refresh": 2,
+                "regex": "",
+                "sort": 1,
+                "tagValuesQuery": "",
+                "tags": [ ],
+                "tagsQuery": "",
+                "type": "query",
+                "useTags": false
+            }
+          ]
+      },
+      "time": {
+          "from": "now-7d",
+          "to": "now"
+      },
+      "timepicker": {
+          "refresh_intervals": [
+            "5s",
+            "10s",
+            "30s",
+            "1m",
+            "5m",
+            "15m",
+            "30m",
+            "1h",
+            "2h",
+            "1d"
+          ],
+          "time_options": [
+            "5m",
+            "15m",
+            "1h",
+            "6h",
+            "12h",
+            "24h",
+            "2d",
+            "7d",
+            "30d"
+          ]
+      },
+      "timezone": "",
+      "title": "Strimzi / Kafka Fleet Panel / Compute Resources / Persistent Volumes",
+      "uid": "3aa63e28e57e5e48febcd3f5aead600e2c5afa9e",
+      "version": 0
+    }


### PR DESCRIPTION
JIRA Link: https://issues.redhat.com/browse/MGDSTRM-199

Addition of Kafka cluster - kubernetes compute metrics dashboards.
New dashbaords for namepsace level - CPU/Memory/Disk and netwrok have been created.

<!--  Issue these changes relate to -->
## What
Creation of new Kafka cluster kubernetes compute resource metrics using USE method
<!-- Why these changes are required -->
## Why
Fleet wide view to see which Kafka clusters are used most and help the SRE to monitor and watch the critical compute resources.

<!-- How this PR implements these changes  -->
## How
New dashboards are added for the respective metrics



