### PR TITLE
Added affinity rule to avoid running pods on infra nodes

### DIFF
--- a/install/resources/monitoring-cluster/promtail/promtail.yaml
+++ b/install/resources/monitoring-cluster/promtail/promtail.yaml
@@ -115,6 +115,13 @@ spec:
       labels:
         app: <name>
     spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: node-role.kubernetes.io/infra
+                    operator: DoesNotExist
       serviceAccountName: <name>
       volumes:
         - name: config


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What
Added affinity rule for promtail DaemonSet to prevent pods to be scheduled to infra nodes

<!-- Why these changes are required -->
## Why
Promtail DaemonSet for Onservatorium ignores taints that created on OSD infra nodes 
```
   taints:
    - effect: PreferNoSchedule
      key: node-role.kubernetes.io/infra
```
increasing resource usage on nodes that won't be used to host kafka components . (We also potentially can have other promtail daemonset for local loki instance)
<!-- How this PR implements these changes  -->
## How
Updated DaemonSet definition in promtail.yaml file 
