### PR TITLE
add script for cluster extension

### DIFF
--- a/scripts/extend_staging_osd.sh
+++ b/scripts/extend_staging_osd.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# This script is used to extend the lifetime of the OSD  staging cluster (used for mas-sso) by 7 days.
+# It will be run automatically by a Jenkins job, you should not need to invoke this manually
+# Required env vars:
+# - OCM_TOKEN: clientToken used by OCM to login to staging environment
+# - OSD_STAGE_CLUSTER_ID: the id of the staging cluster to extend lifetime for
+
+set -e
+
+docker pull quay.io/app-sre/mk-ci-tools:latest
+docker run -u $(id -u) \
+    -e OCM_TOKEN="$OCM_TOKEN" \
+	  quay.io/app-sre/mk-ci-tools:latest extend_cluster_lifetime.sh "$OSD_STAGE_CLUSTER_ID"


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What

https://issues.redhat.com/browse/MGDSTRM-953

<!-- Why these changes are required -->
## Why

The current automation for extending cluster expiration uses a script in the managed-service-api repo which specifies to use a clientId and Secret for a ci user. We want to re-use the logic but use a clientToken instead, since this will avoid having to add extra roles to the ci user.

<!-- How this PR implements these changes  -->
## How

Adds the logic for the script to extend the cluster expiration but specifying a clientToken instead of a secret which pulls from vault. The automation will then run this script to extend the cluster expiration.

There will be a follow up MR against app-interface to switch the job to use this script.
