### PR TITLE
for alt execution use stop-instances instead of reboot-instances

### DIFF
--- a/sops/restart-master-nodes.asciidoc
+++ b/sops/restart-master-nodes.asciidoc
@@ -70,10 +70,19 @@ oc get machine <MACHINE_NAME> -n openshift-machine-api -o yaml | grep providerID
 
 *Alternative execution using aws cli*
 
+To use the aws cli you need to configure it with the secret access key and access key id, generally these should be available in vault. This command will ask you to input the secret access key and access key id.
+
 ```sh
-aws ec2 reboot-instances --instance-ids <instance_id>
+aws configure
+```
+To stop start the master instance you can then run these commands.
+```sh
+aws ec2 stop-instances --instance-ids <instance_id>
 ```
 
+```sh
+aws ec2 start-instances --instance-ids <instance-id>
+```
 == Validate
 
 . Verify the instance is in an up and running state


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What

<!-- Why these changes are required -->
## Why
Specify to use stop-instances and start-instances instead of reboot-instances.
<!-- How this PR implements these changes  -->
## How
By specifying to use stop-instances and start-instances instead of reboot-instances.

