### PR TITLE
SOP to explain logging into OSD cluster with kubeadmin

### DIFF
--- a/sops/accessing_kubeadmin_idp_in_osd.asciidoc
+++ b/sops/accessing_kubeadmin_idp_in_osd.asciidoc
@@ -1,0 +1,44 @@
+// begin header
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+:numbered:
+:toc: macro
+:toc-title: pass:[<b>Table of Contents</b>]
+// end header
+= Accessing Kubeadmin IDP in OSD
+
+toc::[]
+
+== Description
+
+The purpose of this SOP is to describe the process of logging into an OSD 
+cluster as kubeadmin when the kubeadmin option is not available from the landing page 
+list of identity providers.
+
+== Prerequisites
+
+1. The target OSD cluster which has been successfully provisioned
+2. kubeadmin credentials
+
+== Execute/Resolution
+
+To access the login page for the `kubeadmin` user 
+
+1. Navigate to your OSD console.
+2. Select the login for `OpenShift_SRE`
+3. Edit the url of the login page your are redirected to
+4. Change OpenShift_SRE to kube:admin, and %3DOpenShift_SRE to %3Dkubeadmin in the url and hit enter
+5. You will be redirected to a login page and can now use your kubeadmin credentials to login. 
+
+== Validate
+
+None
+
+== Troubleshooting
+
+None


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## https://issues.redhat.com/browse/MGDSTRM-1613

<!-- Why these changes are required -->
## The kubeadmin IDP is no longer visible when you navigate to OSD console login page.

<!-- How this PR implements these changes  -->
## The PR is an SOP to explain how to access the kubeadmin IDP login page

