### PR TITLE
MGDSTRM-1571 Not Ready Panel showing incorrect values in fleet dashboard

### DIFF
--- a/install/resources/monitoring-global/dashboards/fleet.yaml
+++ b/install/resources/monitoring-global/dashboards/fleet.yaml
@@ -621,7 +621,7 @@ spec:
           "tableColumn": "",
           "targets": [
             {
-              "expr": " sum(strimzi_resources{kind=~\"Kafka\"}) - sum(strimzi_resource_state{kind=~\"Kafka\"})",
+              "expr": " count(strimzi_resource_state{kind=~\"Kafka\"} == 0)",
               "instant": true,
               "interval": "",
               "legendFormat": "",


### PR DESCRIPTION

Not Ready Panel show incorrect values(Negative Integer)

There is a bug reported strimzi/strimzi-kafka-operator#4387
This change will just check for strimzi_resource_state with boolean status 0 thus it should avoid negative value.