### PR TITLE
add make target for observability operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@ The options are available as separate `make` targets from the `install` folder.
 cd install
 ```
 
+### Installing observability operator
+
+The Observability Operator install requires some variables to be set
+
+|Variable | Use|
+|------------|-------|
+|OBSERVABILITY_RESOURCES_GH | Github URL for observability resources. Defaults to [observability-resources-mk](https://api.github.com/repos/bf2fc6cc711aee1a0c2a/observability-resources-mk/contents)|
+|ACCESS_TOKEN | Github access token to pull observability resources |
+|DEX_PASSWORD | Password for accessing dex|
+|DEX_SECRET | Secret for accessing dex|
+|DEX_USERNAME | Username for accessing dex |
+
+If you want to point to a local or non-default observatorium instance, edit the URL in your fork of the [resource file](https://github.com/bf2fc6cc711aee1a0c2a/observability-resources-mk/blob/main/development/index.json) and use the OBSERVABILITY_RESOURCES_GH variable to instatiate the operator with that config.
+
+Once the make recipe has completed the observability operator catalogue and config is deployed in the *kafka-observability* namespace. 
+
+* Click on `Operatorhub` in this namespace under the `Operators` tab in the left nav bar.
+* Click the entry under `Provider Type` for `observability-operator-manifests`
+* Click on `observability-operator`
+* Click `install`
+
+
 ### 1) Install *everything*
 
 **Caution:** You probably don't want to do this. Consider installing just the in-cluster components or just the global components in a single cluster.
@@ -34,7 +56,7 @@ cd install
 The following things will be installed:
 
 * global monitoring components for centralised metrics
-* cluster-wide monitoring components, configured to send metrics centrally
+* observability operator
 * strimzi operator
 * strimzi monitoring components to hook into cluster-wide monitoring components
 * a kafka cluster
@@ -57,14 +79,14 @@ make install/monitoring/global
 
 The following things will be installed:
 
-* cluster-wide monitoring components, configured to send metrics centrally
+* observability operator catalogue source
 * strimzi operator
 * strimzi monitoring components to hook into cluster-wide monitoring components
 * a kafka cluster
 
 ```sh
 make install/strimzi/operator
-make install/monitoring/cluster
+make install/observability
 make install/kafka/cr
 ```
 
@@ -86,19 +108,14 @@ This option is useful if you already have a cluster with the strimzi operator ru
 
 The following things will be installed:
 
-* cluster-wide monitoring components, configured to send metrics centrally
-* strimzi monitoring components to hook into cluster-wide monitoring components
+* observabiliy operator
 
 
 ```sh
-make install/monitoring/cluster
+make install/observability
 ```
 
-To specify which namespace strimzi & kafka are in, run the cmd with the following vars:
-
-```sh
-STRIMZI_OPERATOR_NAMESPACE=my-strimzi-ns KAFKA_CLUSTER_NAMESPACE=my-kafka-ns make install/monitoring/cluster
-```
+Once the makefile has completed install the observability-operator from Operatorhub.
 
 ### 6) Install *Observatorium*
 
@@ -167,6 +184,7 @@ The following namespaces are created:
 * *managed-services-monitoring-global*: contains the global monitoring stack including Grafana, Thanos Receiver and Thanos Querier
 * *managed-services-monitoring-prometheus*: contains the on cluster Prometheus that scrapes Kafka metrics
 * *managed-services-monitoring-grafana*: contains the on cluster Grafana instance
+* *kafka-observability* contains the observability operator catalogue source
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -39,15 +39,15 @@ The Observability Operator install requires some variables to be set
 |DEX_SECRET | Secret for accessing dex|
 |DEX_USERNAME | Username for accessing dex |
 
+The Observability stack requires a Personal Access Token to read externalized configuration from within the bf2 organization. For development cycles, you will need to generate a personal token for your own GitHub user (with bf2 access) and place the value in the ConfigMap.
+To generate a new token:
+* Follow the steps found [here](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token), making sure to check ONLY the repo box at the top of the scopes/permissions list (which will check the 3 subcategory boxes beneath it).
+* Copy the value of your Personal Access Token to a secure private location. Once you leave the page, you cannot access the value again & you will be forced to reset the token to receive a new value should you lose the original.
+* Take care not to push your PAT to any repository as if you do, GitHub will automatically revoke your token as soon as you push and you'll need to follow this process again to generate a new token.
+
 If you want to point to a local or non-default observatorium instance, edit the URL in your fork of the [resource file](https://github.com/bf2fc6cc711aee1a0c2a/observability-resources-mk/blob/main/development/index.json) and use the OBSERVABILITY_RESOURCES_GH variable to instatiate the operator with that config.
 
-Once the make recipe has completed the observability operator catalogue and config is deployed in the *kafka-observability* namespace. 
-
-* Click on `Operatorhub` in this namespace under the `Operators` tab in the left nav bar.
-* Click the entry under `Provider Type` for `observability-operator-manifests`
-* Click on `observability-operator`
-* Click `install`
-
+Once the make recipe has completed the observability operator and config is deployed in the *kafka-observability* namespace. 
 
 ### 1) Install *everything*
 

--- a/install/Makefile
+++ b/install/Makefile
@@ -15,6 +15,17 @@ export GLOBAL_THANOS_QUERIER ?= kafka-thanos-querier
 export GLOBAL_GRAFANA ?= kafka-grafana-global
 export GLOBAL_LOKI ?= kafka-loki-global
 
+export OBSERVABILITY_NAMESPACE ?=kafka-observability
+export OBSERVABILITY_RESOURCES_GH ?=https://api.github.com/repos/bf2fc6cc711aee1a0c2a/observability-resources-mk/contents
+export ACCESS_TOKEN ?=anaccesstoken
+export DEX_PASSWORD ?=dex-password
+export DEX_SECRET ?=dex-secret
+export DEX_USERNAME ?=dex-username
+
+DEX_P_B := $(shell echo ${DEX_PASSWORD} | base64)
+DEX_S_B := $(shell echo ${DEX_SECRET} | base64)
+DEX_U_B := $(shell echo ${DEX_USERNAME} | base64)
+
 export LOGS_MAX_AGE ?= 1d
 export LOGS_STORAGE ?= 60G
 
@@ -123,7 +134,29 @@ test/chaos:
 setup/observatorium:
 	make -C resources/observatorium setup
 
-all: install/strimzi/operator install/kafka/cr install/monitoring/global install/monitoring/cluster
+.PHONY: install/observability
+install/observability:
+	@ mkdir -p ./$(BUILD_DIR)/observability-operator
+
+	@ cp $(RESOURCE_FILES_DIR)/observability-operator/secrets.yaml ./$(BUILD_DIR)/observability-operator/
+	@ sed -i 's/<DEX_PASSWORD>/$(DEX_P_B)/' ./$(BUILD_DIR)/observability-operator/secrets.yaml
+	@ sed -i 's/<DEX_SECRET>/$(DEX_S_B)/' ./$(BUILD_DIR)/observability-operator/secrets.yaml
+	@ sed -i 's/<DEX_USERNAME>/$(DEX_U_B)/' ./$(BUILD_DIR)/observability-operator/secrets.yaml	
+
+	@ cp $(RESOURCE_FILES_DIR)/observability-operator/configmap.yaml ./$(BUILD_DIR)/observability-operator/
+	@ sed -i 's/<ACCESS_TOKEN>/$(ACCESS_TOKEN)/' ./$(BUILD_DIR)/observability-operator/configmap.yaml
+	@ sed -i 's,<OBSERVABILITY_RESOURCES_GH>,$(OBSERVABILITY_RESOURCES_GH),' ./$(BUILD_DIR)/observability-operator/configmap.yaml
+
+	@ -oc new-project $(OBSERVABILITY_NAMESPACE)
+	@oc apply -f ./resources/observability-operator/catalogue-source.yaml
+	@oc apply -f ./${BUILD_DIR}/observability-operator/configmap.yaml
+	@oc apply -f ./${BUILD_DIR}/observability-operator/secrets.yaml
+
+.PHONY: uninstall/observability
+uninstall/observability:
+	@oc delete project $(OBSERVABILITY_NAMESPACE)
+
+all: install/strimzi/operator install/kafka/cr install/monitoring/global install/observability
 	@echo "done installing kafka monitoring demo"
 
 clean: uninstall/kafka/cr uninstall/strimzi/operator uninstall/monitoring/global uninstall/monitoring/cluster

--- a/install/Makefile
+++ b/install/Makefile
@@ -44,6 +44,15 @@ export KAFKA_UUID ?= $(shell uuidgen | tr '[:upper:]' '[:lower:]')
 RESOURCE_FILES_DIR ?= ./resources
 BUILD_DIR := build
 
+OSTYPE := $(shell uname -s)
+
+ifeq ($(OSTYPE), Linux)
+	SED := sed
+endif
+ifeq ($(OSTYPE), Darwin)
+	SED := gsed
+endif
+
 .PHONY: install/monitoring/cluster
 install/monitoring/cluster:
   # create yaml files
@@ -139,25 +148,25 @@ install/observability:
 	@ mkdir -p ./$(BUILD_DIR)/observability-operator
 
 	@ cp $(RESOURCE_FILES_DIR)/observability-operator/secrets.yaml ./$(BUILD_DIR)/observability-operator/
-	@ sed -i 's/<DEX_PASSWORD>/$(DEX_P_B)/' ./$(BUILD_DIR)/observability-operator/secrets.yaml
-	@ sed -i 's/<DEX_SECRET>/$(DEX_S_B)/' ./$(BUILD_DIR)/observability-operator/secrets.yaml
-	@ sed -i 's/<DEX_USERNAME>/$(DEX_U_B)/' ./$(BUILD_DIR)/observability-operator/secrets.yaml	
+	@ $(SED) -i 's/<DEX_PASSWORD>/$(DEX_P_B)/' ./$(BUILD_DIR)/observability-operator/secrets.yaml
+	@ $(SED) -i 's/<DEX_SECRET>/$(DEX_S_B)/' ./$(BUILD_DIR)/observability-operator/secrets.yaml
+	@ $(SED) -i 's/<DEX_USERNAME>/$(DEX_U_B)/' ./$(BUILD_DIR)/observability-operator/secrets.yaml	
 
 	@ cp $(RESOURCE_FILES_DIR)/observability-operator/configmap.yaml ./$(BUILD_DIR)/observability-operator/
-	@ sed -i 's/<ACCESS_TOKEN>/$(ACCESS_TOKEN)/' ./$(BUILD_DIR)/observability-operator/configmap.yaml
-	@ sed -i 's,<OBSERVABILITY_RESOURCES_GH>,$(OBSERVABILITY_RESOURCES_GH),' ./$(BUILD_DIR)/observability-operator/configmap.yaml
+	@ $(SED) -i 's/<ACCESS_TOKEN>/$(ACCESS_TOKEN)/' ./$(BUILD_DIR)/observability-operator/configmap.yaml
+	@ $(SED) -i 's,<OBSERVABILITY_RESOURCES_GH>,$(OBSERVABILITY_RESOURCES_GH),' ./$(BUILD_DIR)/observability-operator/configmap.yaml
 
 	@ cp $(RESOURCE_FILES_DIR)/observability-operator/namespace.yaml ./$(BUILD_DIR)/observability-operator/
-	@ sed -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/namespace.yaml
+	@ $(SED) -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/namespace.yaml
 
 	@ cp $(RESOURCE_FILES_DIR)/observability-operator/catalogue-source.yaml ./$(BUILD_DIR)/observability-operator/
-	@ sed -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/catalogue-source.yaml
+	@ $(SED) -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/catalogue-source.yaml
 
 	@ cp $(RESOURCE_FILES_DIR)/observability-operator/subscription.yaml ./$(BUILD_DIR)/observability-operator/
-	@ sed -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/subscription.yaml
+	@ $(SED) -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/subscription.yaml
 
 	@ cp $(RESOURCE_FILES_DIR)/observability-operator/operatorgroup.yaml ./$(BUILD_DIR)/observability-operator/
-	@ sed -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/operatorgroup.yaml
+	@ $(SED) -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/operatorgroup.yaml
 
 	@oc apply -f ./${BUILD_DIR}/observability-operator/namespace.yaml
 	@oc apply -f ./${BUILD_DIR}/observability-operator/configmap.yaml

--- a/install/Makefile
+++ b/install/Makefile
@@ -147,13 +147,30 @@ install/observability:
 	@ sed -i 's/<ACCESS_TOKEN>/$(ACCESS_TOKEN)/' ./$(BUILD_DIR)/observability-operator/configmap.yaml
 	@ sed -i 's,<OBSERVABILITY_RESOURCES_GH>,$(OBSERVABILITY_RESOURCES_GH),' ./$(BUILD_DIR)/observability-operator/configmap.yaml
 
-	@ -oc new-project $(OBSERVABILITY_NAMESPACE)
-	@oc apply -f ./resources/observability-operator/catalogue-source.yaml
+	@ cp $(RESOURCE_FILES_DIR)/observability-operator/namespace.yaml ./$(BUILD_DIR)/observability-operator/
+	@ sed -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/namespace.yaml
+
+	@ cp $(RESOURCE_FILES_DIR)/observability-operator/catalogue-source.yaml ./$(BUILD_DIR)/observability-operator/
+	@ sed -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/catalogue-source.yaml
+
+	@ cp $(RESOURCE_FILES_DIR)/observability-operator/subscription.yaml ./$(BUILD_DIR)/observability-operator/
+	@ sed -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/subscription.yaml
+
+	@ cp $(RESOURCE_FILES_DIR)/observability-operator/operatorgroup.yaml ./$(BUILD_DIR)/observability-operator/
+	@ sed -i 's/<NAMESPACE>/$(OBSERVABILITY_NAMESPACE)/' ./$(BUILD_DIR)/observability-operator/operatorgroup.yaml
+
+	@oc apply -f ./${BUILD_DIR}/observability-operator/namespace.yaml
 	@oc apply -f ./${BUILD_DIR}/observability-operator/configmap.yaml
 	@oc apply -f ./${BUILD_DIR}/observability-operator/secrets.yaml
+	@oc apply -f ./${BUILD_DIR}/observability-operator/operatorgroup.yaml	
+	@oc apply -f ./${BUILD_DIR}/observability-operator/catalogue-source.yaml
+	@oc apply -f ./${BUILD_DIR}/observability-operator/subscription.yaml
+
+	@ rm- rf ${BUILD_DIR}
 
 .PHONY: uninstall/observability
 uninstall/observability:
+	@oc delete observability observability-stack -n $(OBSERVABILITY_NAMESPACE)
 	@oc delete project $(OBSERVABILITY_NAMESPACE)
 
 all: install/strimzi/operator install/kafka/cr install/monitoring/global install/observability

--- a/install/resources/observability-operator/catalogue-source.yaml
+++ b/install/resources/observability-operator/catalogue-source.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: observability-operator-manifests
+  namespace: kafka-observability
+spec:
+  sourceType: grpc
+  image: quay.io/integreatly/observability-operator-index:v2.0.0

--- a/install/resources/observability-operator/catalogue-source.yaml
+++ b/install/resources/observability-operator/catalogue-source.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: observability-operator-manifests
-  namespace: kafka-observability
+  namespace: <NAMESPACE>
 spec:
   sourceType: grpc
   image: quay.io/integreatly/observability-operator-index:v2.0.0

--- a/install/resources/observability-operator/configmap.yaml
+++ b/install/resources/observability-operator/configmap.yaml
@@ -1,0 +1,11 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kafka-observability-configuration
+  namespace: kafka-observability
+  labels:
+    configures: observability-operator
+data:
+  access_token: '<ACCESS_TOKEN>'
+  channel: development
+  repository: '<OBSERVABILITY_RESOURCES_GH>'

--- a/install/resources/observability-operator/configmap.yaml
+++ b/install/resources/observability-operator/configmap.yaml
@@ -9,3 +9,4 @@ data:
   access_token: '<ACCESS_TOKEN>'
   channel: development
   repository: '<OBSERVABILITY_RESOURCES_GH>'
+  

--- a/install/resources/observability-operator/namespace.yaml
+++ b/install/resources/observability-operator/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: <NAMESPACE>
+

--- a/install/resources/observability-operator/operatorgroup.yaml
+++ b/install/resources/observability-operator/operatorgroup.yaml
@@ -1,0 +1,8 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: operatorgroup
+  namespace: <NAMESPACE>
+spec:
+  targetNamespaces:
+    - <NAMESPACE>

--- a/install/resources/observability-operator/secrets.yaml
+++ b/install/resources/observability-operator/secrets.yaml
@@ -1,0 +1,29 @@
+---
+  kind: Secret
+  apiVersion: v1
+  metadata:
+    name: pagerduty
+    namespace: kafka-observability
+  data:
+    PAGERDUTY_KEY: ZHVtbXk=
+  type: Opaque
+---
+  kind: Secret
+  apiVersion: v1
+  metadata:
+    name: deadmanssnitch
+    namespace: kafka-observability
+  data:
+    SNITCH_URL: aHR0cDovL2R1bW15
+  type: Opaque
+---
+  kind: Secret
+  apiVersion: v1
+  metadata:
+    name: observatorium-dex-credentials
+    namespace: kafka-observability
+  data:
+    password: <DEX_PASSWORD>
+    secret: <DEX_SECRET>
+    username: <DEX_USERNAME>
+  type: Opaque

--- a/install/resources/observability-operator/subscription.yaml
+++ b/install/resources/observability-operator/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: observability-operator
+  namespace: <NAMESPACE>
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: observability-operator
+  source: observability-operator-manifests
+  sourceNamespace: <NAMESPACE>


### PR DESCRIPTION
<!--  Issue these changes relate to -->
## What
https://issues.redhat.com/browse/MGDSTRM-1433
<!-- Why these changes are required -->
## Why
The Makefile currently supports installing stand alone grafana and prometheus which does not reflect the actual stack in use.
<!-- How this PR implements these changes  -->
## How
Adds a Makefile recipe for installing the observability operator with instructions for use.
