### PR TITLE
MGDSTRM-1443 - Updated versions of Observatorium images

### DIFF
--- a/install/resources/observatorium/Makefile
+++ b/install/resources/observatorium/Makefile
@@ -1,5 +1,8 @@
+export OBSERVATORIUM_APPS_URL := $(shell oc get --namespace openshift-ingress-operator ingresscontrollers/default --output jsonpath='{.status.domain}{"\n"}')
 export DEX_TOKEN_URL := http://dex-dex.$(OBSERVATORIUM_APPS_URL)
-export GATEWAY_URL := https://observatorium-observatorium.$(OBSERVATORIUM_APPS_URL)
+export OBSERVATORIUM_ROUTE_HOST ?=observatorium-observatorium.$(OBSERVATORIUM_APPS_URL)
+export GATEWAY_URL := https://$(OBSERVATORIUM_ROUTE_HOST)
+
 export LOG_SCRAPE_NAMESPACES ?= '$(STRIMZI_OPERATOR_NAMESPACE)','$(KAFKA_CLUSTER_NAMESPACE)'
 export METRICS_SCRAPE_NAMESPACES ?= '$(STRIMZI_OPERATOR_NAMESPACE)','$(KAFKA_CLUSTER_NAMESPACE)'
 
@@ -33,8 +36,8 @@ create/cr:
 
 .PHONY: create/route
 create/route:
-	@echo "create route"
-	@sed 's/<namespace>/$(OBSERVATORIUM_NAMESPACE)/g' ./route.yaml | cat | oc apply -f -
+	@echo "create route $(OBSERVATORIUM_ROUTE_HOST) in $(OBSERVATORIUM_NAMESPACE) namespace"
+	@sed 's/<namespace>/$(OBSERVATORIUM_NAMESPACE)/g;s/<hosturl>/$(OBSERVATORIUM_ROUTE_HOST)/g' ./route.yaml | cat | oc apply -f -
 
 setup:
 	@echo "updating promtail config to point to $(GATEWAY_URL)"

--- a/install/resources/observatorium/minio.yaml
+++ b/install/resources/observatorium/minio.yaml
@@ -52,7 +52,7 @@ spec:
               value: minio
             - name: MINIO_SECRET_KEY
               value: minio123
-          image: minio/minio
+          image: minio/minio:RELEASE.2021-03-10T05-11-33Z
           imagePullPolicy: Always
           name: minio
           ports:

--- a/install/resources/observatorium/observatorium.yaml
+++ b/install/resources/observatorium/observatorium.yaml
@@ -27,21 +27,21 @@ spec:
           requests:
             storage: 50Gi
   loki:
-    image: 'docker.io/grafana/loki:1.6.1'
+    image: 'docker.io/grafana/loki:2.1.0'
     replicas:
       distributor: 1
       ingester: 3
       querier: 3
-      query_frontend: 1
+      query_frontend: 3
       table_manager: 1
-    version: 1.6.1
+    version: 2.1.0
     volumeClaimTemplate:
       spec:
         accessModes:
           - ReadWriteOnce
         resources:
           requests:
-            storage: 250Mi
+            storage: 1G
   compact:
     enableDownsampling: false
     image: 'quay.io/thanos/thanos:master-2020-08-12-70f89d83'
@@ -82,7 +82,7 @@ spec:
     image: 'quay.io/observatorium/thanos-receive-controller:master-2020-02-06-b66e0c8'
     version: master-2020-02-06-b66e0c8
   api:
-    image: 'quay.io/pb82/observatorium:latest'
+    image: 'quay.io/observatorium/observatorium:master-2020-11-02-v0.1.1-192-ge324057'
     rbac:
       roleBindings:
         - name: test

--- a/install/resources/observatorium/operator.yaml
+++ b/install/resources/observatorium/operator.yaml
@@ -209,7 +209,7 @@ spec:
       containers:
         - args:
             - --log-level=debug
-          image: quay.io/observatorium/observatorium-operator:latest
+          image: quay.io/observatorium/observatorium-operator:master-2020-11-04-acb908d
           imagePullPolicy: Always
           name: observatorium-operator
           resources:

--- a/install/resources/observatorium/route.yaml
+++ b/install/resources/observatorium/route.yaml
@@ -4,7 +4,7 @@ metadata:
   name: observatorium
   namespace: <namespace>
 spec:
-  host: observatorium-observatorium.apps-crc.testing
+  host: <hosturl>
   to:
     kind: Service
     name: observatorium-xyz-observatorium-api


### PR DESCRIPTION
<!--  Issue these changes relate to -->
Some of the components of Observatorium were using **latest** tag in references to the images.Change is required to improve stability and update Observatorium version to be in sync with currently used version in Observatorium As A Service offering 
 
PR also includes minor modification to Observatorium Makefile to automatically populate observatorium API route 




